### PR TITLE
Carry -g & -O through to the `gcc` commands also.

### DIFF
--- a/src/static_julia.jl
+++ b/src/static_julia.jl
@@ -122,22 +122,27 @@ function julia_compile(
         math_mode, depwarn
     )
 
-    shared && build_shared(s_file, joinpath(tmp_dir, o_file), verbose)
+    shared && build_shared(s_file, joinpath(tmp_dir, o_file), verbose, optimize, debug)
 
-    executable && compile_executable(s_file, e_file, cprog, verbose)
+    executable && compile_executable(s_file, e_file, cprog, verbose, optimize, debug)
 
     julialibs && sync_julia_files(verbose)
 
 end
 
 
-function julia_flags()
+function julia_flags(optimize, debug)
     if julia_v07
         command = `$(Base.julia_cmd()) --startup-file=no $(joinpath(dirname(Sys.BINDIR), "share", "julia", "julia-config.jl"))`
-        return `$(Base.shell_split(read(\`$command --allflags\`, String)))`
+        flags = `$(Base.shell_split(read(\`$command --allflags\`, String)))`
+        optimize == nothing || (flags = `$flags -O$optimize`)
+        debug != 2 || (flags = `$flags -g`)
+        return flags
     else
         command = `$(Base.julia_cmd()) --startup-file=no $(joinpath(dirname(JULIA_HOME), "share", "julia", "julia-config.jl"))`
         cflags = `$(Base.shell_split(readstring(\`$command --cflags\`)))`
+        optimize == nothing || (cflags = `$cflags -O$optimize`)
+        debug != 2 || (cflags = `$cflags -g`)
         ldflags = `$(Base.shell_split(readstring(\`$command --ldflags\`)))`
         ldlibs = `$(Base.shell_split(readstring(\`$command --ldlibs\`)))`
         return `$cflags $ldflags $ldlibs`
@@ -145,10 +150,10 @@ function julia_flags()
 end
 
 
-function build_shared(s_file, o_file, verbose = false)
+function build_shared(s_file, o_file, verbose = false, optimize, debug)
     cc = system_compiler()
     bitness = bitness_flag()
-    flags = julia_flags()
+    flags = julia_flags(optimize, debug)
     command = `$cc $bitness -shared -o $s_file $o_file $flags`
     if isapple()
         command = `$command -Wl,-install_name,@rpath/$s_file`
@@ -160,10 +165,10 @@ function build_shared(s_file, o_file, verbose = false)
 end
 
 
-function compile_executable(s_file, e_file, cprog, verbose = false)
+function compile_executable(s_file, e_file, cprog, verbose = false, optimize, debug)
     bitness = bitness_flag()
     cc = system_compiler()
-    flags = julia_flags()
+    flags = julia_flags(optimize, debug)
     command = `$cc $bitness -DJULIAC_PROGRAM_LIBNAME=\"$s_file\" -o $e_file $cprog $s_file $flags`
     if iswindows()
         RPMbindir = PackageCompiler.mingw_dir("bin")


### PR DESCRIPTION
Before this commit, those flags only affected the julia parts of the
script (building object file). This commit changes juliac to also pass
`-g` and `-O` to `gcc` when building a shared library or executable.