### PR TITLE
Modify default program.c to also pass argv[0].

### DIFF
--- a/examples/program.c
+++ b/examples/program.c
@@ -31,10 +31,10 @@ int main(int argc, char *argv[])
     // build arguments array: `String[ unsafe_string(argv[i]) for i in 1:argc ]`
     jl_array_t *ARGS = jl_alloc_array_1d(jl_apply_array_type(jl_string_type, 1), 0);
     JL_GC_PUSH1(&ARGS);
-    jl_array_grow_end(ARGS, argc - 1);
-    for (i = 1; i < argc; i++) {
+    jl_array_grow_end(ARGS, argc);
+    for (i = 0; i < argc; i++) {
         jl_value_t *s = (jl_value_t*)jl_cstr_to_string(argv[i]);
-        jl_arrayset(ARGS, s, i - 1);
+        jl_arrayset(ARGS, s, i);
     }
     // call the work function, and get back a value
     retcode = julia_main(ARGS);


### PR DESCRIPTION
Currently the default program.c is only passing through to `julia_main` the `c` `argv` arguments from index 1 through the end, and skipping `argv[0]`.

This commit changes the default program.c to pass all the argv args to julia_main, including `argv[0]`. It can be useful to know how your code was invoked.

-------------------------

Do you know if there was a reason that it was done that way? It looks like it was just copied over from the import from 2 years ago, so I assume it's okay to change? :)

What do you think? @lucatrv?
@vtjnash -- I think this was your code originally. Do you think it's okay to change the default code to pass all the argv args to julia?