### PR TITLE
make -C pass `--precompiled=no --compilecache=no` to julia.

### DIFF
--- a/src/static_julia.jl
+++ b/src/static_julia.jl
@@ -168,7 +168,9 @@ function build_julia_cmd(
     sysimage == nothing || (julia_cmd.exec[3] = "-J$sysimage")
     push!(julia_cmd.exec, string("--startup-file=", startupfile ? "yes" : "no"))
     compile == nothing || (julia_cmd.exec[4] = "--compile=$compile")
-    cpu_target == nothing || (julia_cmd.exec[2] = "-C$cpu_target")
+    cpu_target == nothing || (julia_cmd.exec[2] = "-C$cpu_target";
+                              push!(julia_cmd.exec, "--precompiled=no");
+                              push!(julia_cmd.exec, "--compilecache=no"))
     optimize == nothing || push!(julia_cmd.exec, "-O$optimize")
     debug == nothing || push!(julia_cmd.exec, "-g$debug")
     inline == nothing || push!(julia_cmd.exec, "--inline=$inline")


### PR DESCRIPTION
You cannot start `julia` with `-Ctarget` where target != your native
target without specifying `--precompiled=no`. Otherwise Julia will
complain that its sysimg doesn't match the target it's running under.

And you cannot import any precompiled packages if they were precompiled
for the wrong target, so we must turn off using precompiled images via
 `--compilecache=no`.

This change will allow you to invoke `juliac.jl -Ctarget` for targets
other than your native target.

------------

This came up when I was trying to build a julia program on my mac, and then
ship it to another mac and run it. Before this change, I was getting `ERROR:
Target architecture mismatch. Please delete or regenerate sys.{so,dll,dylib}.`
but after this change it compiles and distributes and runs successfully on the
other (10 year old!!) mac! :)