### PR TITLE
Add --ccflags option to allow custom compiler flags.

### DIFF
--- a/juliac.jl
+++ b/juliac.jl
@@ -99,8 +99,8 @@ Base.@ccallable function julia_main(args::Vector{String})::Cint
         "--ccflags"
             arg_type = String
             default = nothing
-            # metavar = ""  # TODO(NHDaly): Any suggestions on what to put here?
-            help = "custom flag(s) to pass to compiler when building shared library or executable"
+            metavar = "<flags>"
+            help = "pass custom flags to system compiler when building shared library or executable"
     end
 
     s.epilog = """

--- a/juliac.jl
+++ b/juliac.jl
@@ -96,7 +96,7 @@ Base.@ccallable function julia_main(args::Vector{String})::Cint
             metavar = "{yes|no|error}"
             range_tester = (x -> x == "yes" || x == "no" || x == "error")
             help = "set syntax and method deprecation warnings"
-        "--ccflags"
+        "--cc-flags"
             arg_type = String
             default = nothing
             metavar = "<flags>"

--- a/juliac.jl
+++ b/juliac.jl
@@ -96,6 +96,11 @@ Base.@ccallable function julia_main(args::Vector{String})::Cint
             metavar = "{yes|no|error}"
             range_tester = (x -> x == "yes" || x == "no" || x == "error")
             help = "set syntax and method deprecation warnings"
+        "--ccflags"
+            arg_type = String
+            default = nothing
+            # metavar = ""  # TODO(NHDaly): Any suggestions on what to put here?
+            help = "custom flag(s) to pass to compiler when building shared library or executable"
     end
 
     s.epilog = """

--- a/src/static_julia.jl
+++ b/src/static_julia.jl
@@ -55,7 +55,7 @@ compiles the Julia file at path `juliaprog` with keyword arguments:
     depwarn {yes|no|error}    set syntax and method deprecation warnings
 
     cc                        system C compiler
-    cc_flags <flags>           pass custom flags to system compiler when building shared library or executable
+    cc_flags <flags>          pass custom flags to system compiler when building shared library or executable
 """
 function static_julia(
         juliaprog;
@@ -65,8 +65,7 @@ function static_julia(
     	sysimage = nothing, compile = nothing, cpu_target = nothing,
     	optimize = nothing, debug = nothing, inline = nothing,
     	check_bounds = nothing, math_mode = nothing, depwarn = nothing,
-    	cc = system_compiler(),
-        cc_flags = nothing
+    	cc = system_compiler(), cc_flags = nothing
     )
 
     verbose && quiet && (quiet = false)

--- a/src/system_image.jl
+++ b/src/system_image.jl
@@ -42,7 +42,7 @@ function compile_system_image(sysimg_path, cpu_target = nothing; debug = false)
 
         build_shared(
             "$sysimg_path.$(Libdl.dlext)", "$sysimg_path.o",
-            true, nothing, debug ? 2 : nothing
+            true, nothing, debug ? 2 : nothing, nothing
         )
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -35,10 +35,10 @@ end
         cd(build) do
             @test success(`./$("hello$(executable_ext())")`)
         end
-        @testset "--ccflags" begin
+        @testset "--cc-flags" begin
             # Try passing `--help` to $cc. This should work for any system compiler.
             # Then grep the output for "-g", which should be present on any system.
-            @test contains(readstring(`$julia $juliac -se --ccflags='--help' $jlfile $cfile $build`), "-g")
+            @test contains(readstring(`$julia $juliac -se --cc-flags='--help' $jlfile $cfile $build`), "-g")
             # Just as a control, make sure that without passing '--help', we don't see "-g"
             @test !contains(readstring(`$julia $juliac -se $jlfile $cfile $build`), "-g")
         end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -35,6 +35,13 @@ end
         cd(build) do
             @test success(`./$("hello$(executable_ext())")`)
         end
+        @testset "--ccflags" begin
+            # Try passing `--help` to $cc. This should work for any system compiler.
+            # Then grep the output for "-g", which should be present on any system.
+            @test contains(readstring(`$julia $juliac -se --ccflags='--help' $jlfile $cfile $build`), "-g")
+            # Just as a control, make sure that without passing '--help', we don't see "-g"
+            @test !contains(readstring(`$julia $juliac -se $jlfile $cfile $build`), "-g")
+        end
     end
 end
 


### PR DESCRIPTION
Allows the user to specify compiler flags to be passed to `cc` for
building the shared object and the final executable.

---------

@lucatrv: I'm not sure about the exact name of this flag. Maybe it should just
be `cflags`? Or maybe `extra_cflags` or something?


Thanks!