### PR TITLE
precompile and compilecache turned off

### DIFF
--- a/src/snooping.jl
+++ b/src/snooping.jl
@@ -32,12 +32,14 @@ function snoop(path, compilationfile, csv)
     delims = r"([\{\} \n\(\),])_([\{\} \n\(\),])"
     tmp_mod = eval(:(module $(gensym()) end))
     open(compilationfile, "w") do io
+		println(io, "Sys.__init__()")
+		println(io, "Base.early_init()")
         for (k, v) in pc
             k == :unknown && continue
             try
-                eval(tmp_mod, :(using $k))
-                println(io, "using $k")
-                info("using $k")
+                eval(tmp_mod, :(import $k))
+                println(io, "import $k")
+                info("import $k")
             catch e
                 warn("Module not found: $k")
             end

--- a/src/static_julia.jl
+++ b/src/static_julia.jl
@@ -15,7 +15,7 @@ else
 end
 
 system_compiler() = gcc
-bitness_flag() = Int == Int32 ? "-m32" : "-m64"
+bitness_flag() = Sys.ARCH == :aarch64 ? `` : Int == Int32 ? "-m32" : "-m64"
 executable_ext() = (iswindows() ? ".exe" : "")
 
 function mingw_dir(folders...)

--- a/src/static_julia.jl
+++ b/src/static_julia.jl
@@ -168,15 +168,15 @@ function build_julia_cmd(
     sysimage == nothing || (julia_cmd.exec[3] = "-J$sysimage")
     push!(julia_cmd.exec, string("--startup-file=", startupfile ? "yes" : "no"))
     compile == nothing || (julia_cmd.exec[4] = "--compile=$compile")
-    cpu_target == nothing || (julia_cmd.exec[2] = "-C$cpu_target";
-                              push!(julia_cmd.exec, "--precompiled=no");
-                              push!(julia_cmd.exec, "--compilecache=no"))
+    cpu_target == nothing || (julia_cmd.exec[2] = "-C$cpu_target";)
     optimize == nothing || push!(julia_cmd.exec, "-O$optimize")
     debug == nothing || push!(julia_cmd.exec, "-g$debug")
     inline == nothing || push!(julia_cmd.exec, "--inline=$inline")
     check_bounds == nothing || push!(julia_cmd.exec, "--check-bounds=$check_bounds")
     math_mode == nothing || push!(julia_cmd.exec, "--math-mode=$math_mode")
     depwarn == nothing || (julia_cmd.exec[5] = "--depwarn=$depwarn")
+    push!(julia_cmd.exec, "--precompiled=no");
+    push!(julia_cmd.exec, "--compilecache=no")
     julia_cmd
 end
 


### PR DESCRIPTION
This PR includes:

1) adding compilecache=no and precompile=no always , both when snooping and when building

2) switch to import statements in precompile.jl to avoid name collisions (at least to avoid warnings about those collisions)

3)add
 
```
Sys.__init__()
Base.early_init()

```
to the beginning of precompile.jl , in order to have JULIA_HOME defined properly in the compiled code.

4) fix a bug where package compiling would fail on an arm-processor based Julia , since gcc on Arm does not have bitness flags