### PR TITLE
Easy incremental bootstrapping

### DIFF
--- a/src/PackageCompiler.jl
+++ b/src/PackageCompiler.jl
@@ -24,6 +24,7 @@ include("static_julia.jl")
 include("api.jl")
 include("snooping.jl")
 include("system_image.jl")
+include("bootstrapping.jl")
 
 const sysimage_binaries = (
     "sys.o", "sys.$(Libdl.dlext)", "sys.ji", "inference.o", "inference.ji"
@@ -114,9 +115,6 @@ function compile_package(packages...; kw_args...)
     compile_package(args...; kw_args...)
 end
 
-
-
-
 """
     compile_package(packages::Tuple{String, String}...; force = false, reuse = false, debug = false)
 
@@ -165,9 +163,6 @@ function compile_package(packages::Tuple{String, String}...; force = false, reus
     imgfile
 end
 
-
-
-
 function __init__()
     if Base.julia_cmd().exec[2] != "-Cnative"
         warn("Your Julia system image is not compiled natively for this CPU architecture.
@@ -177,5 +172,6 @@ function __init__()
 end
 
 export compile_package, revert, force_native_image!, executable_ext, build_executable
+export stop_log_bootstrap, bootstrap, log_bootstrap
 
 end # module

--- a/src/api.jl
+++ b/src/api.jl
@@ -15,10 +15,11 @@ function build_sysimg(sysimg_path, userimg_path = nothing;
         verbose = false, quiet = false,
         cpu_target = nothing, optimize = nothing,
         debug = nothing, inline = nothing, check_bounds = nothing,
-        math_mode = nothing
+        math_mode = nothing,
+        sysimg = get_backup!(contains(basename(Base.julia_cmd().exec[1]), "debug"), cpu_target)
     )
-    # build vanilla backup system image
-    clean_sysimg = get_backup!(contains(basename(Base.julia_cmd().exec[1]), "debug"), cpu_target)
+    # build vanilla backup system image by default
+
     static_julia(
         userimg_path, juliaprog_basename = "sys",
 
@@ -27,7 +28,7 @@ function build_sysimg(sysimg_path, userimg_path = nothing;
         math_mode = math_mode, verbose = verbose, quiet = quiet,
 
         cprog = nothing, builddir = sysimg_path,
-        clean = false, sysimage = clean_sysimg,
+        clean = false, sysimage = sysimg,
         compile = nothing, depwarn = nothing, autodeps = false,
         object = true, shared = true, executable = false, julialibs = false,
     )

--- a/src/bootstrapping.jl
+++ b/src/bootstrapping.jl
@@ -1,5 +1,15 @@
 
 bootstrap_fid = nothing
+"""
+    log_bootstrap(discard_last_session = false)
+
+starts logging every function that is being compiled, to be later bootstrapped on top
+of the existing sysimg `bootstrap(;force = true)`
+
+
+`log_bootstrap(true)` erases previously logged function list
+
+"""
 function log_bootstrap(discard_last_session = false)
     stop_log_bootstrap()
     mod = discard_last_session ? "w" : "a+"
@@ -7,17 +17,51 @@ function log_bootstrap(discard_last_session = false)
     ccall(:jl_dump_compiles, Void, (Ptr{Void},), bootstrap_fid.handle)
 end
 
+"""
+    stop_log_bootstrap()
+
+stops logging
+
+"""
 function stop_log_bootstrap()
     global bootstrap_fid
     (bootstrap_fid != nothing) && close(bootstrap_fid)
     bootstrap_fid = nothing
 end
 
+"""
+    bootstrap(;vanilla = false, force = false)
+
+bootstraps a precompilation file for all methods logged using `log_bootstrap()`.
+if your code is in a module that is discoverable without any modification to
+`LOAD_PATH` then it should be blacklisted `blacklist(modname)` along with
+any discoverable module that imports it. bootstrapping clears the logged file,
+bootstrapping can be repeated and it is cumulative
+
+"""
 function bootstrap(;vanilla = false, force = false)
     generate_bootstrap_jl()
+    if length(intersect(blacklist(),bootstrapped_modules())) > 0
+        warn("Blacklisted modules found in previous bootstrap, reverting to
+                vanilla sysimg ( clean base )")
+        vanilla = true
+    end
     bootstrap(sysimg_folder("bootstrap.jl"); vanilla = vanilla, force = force)
 end
 
+"""
+    bootstrap(bootstrap_jl::String;vanilla = false, force = false)
+
+bootstraps `bootstrap_jl` to the sysimg, so that at startup `julia` is in the
+state as if `include(bootstrap_jl)` has already been executed.
+
+
+set `force=true`
+to copy over the new sysimg, or follow the instruction at the end to do it manually.
+set `vanilla = true` to bootstrap over a clean sysimg in case the current sysimg is
+already a bootstraped one , and you wish to start from start
+
+"""
 function bootstrap(bootstrap_jl::String;vanilla = false, force = false)
     start_path = pwd()
     image_path = sysimg_folder()
@@ -37,23 +81,28 @@ function bootstrap(bootstrap_jl::String;vanilla = false, force = false)
     catch err
         warn(err)
         info("try manually copying using\n cp $source $dest")
+        info("or manually start julia with the new sysimg using\n julia -J$source")
     end
-    cd(start_path)
-    log_bootstrap(true)
+    cd(start_path) #return to the path where we entered the function
+    log_bootstrap(true) #clear the log file
 end
 
 parseable(ln) = try parse(ln);true;catch false; end
 function generate_bootstrap_jl()
     stop_log_bootstrap()
+    blacklisted = append!(["PackageCompiler","Main"],blacklist())
+
     pc = SnoopCompile.read(sysimg_folder("bootstrap.csv"))[2]
-    pc =  SnoopCompile.parcel(pc;blacklist = ["Main"])
-    blacklist = [:PackageCompiler,:unknown,:Main]
+    pc =  SnoopCompile.parcel(pc;blacklist = blacklisted)
+
+    push!(blacklisted,"unknown")
+
     open(sysimg_folder("bootstrap.jl"), "w") do io
         println(io,"try JULIA_HOME;catch Sys.__init__();Base.early_init();end")
 
         for (k,v) in pc
-            k in blacklist && continue
-            println(io,"println(\"precompiling $k\")")
+            string(k) in blacklisted && continue
+            println(io,"println(\"Precompiling $k\")")
             println(io,"try\n   import $k")
             foreach(unique(v)) do ln
                 parseable(ln) && println(io,try_catch_string_tabbed(ln;tabs=1))
@@ -66,6 +115,8 @@ function generate_bootstrap_jl()
         foreach(unique(v_unknown)) do ln
             parseable(ln) && println(io,try_catch_string_tabbed(ln))
         end
+
+        println(io,"""println("Done Precompiling!!")""")
 
     end
 end
@@ -80,3 +131,54 @@ try_catch_string_tabbed(ln::String;tabs = 0) = begin
 end
 
 sys_size_MB() = stat(joinpath(default_sysimg_path(),"sys.$(Libdl.dlext)")).size/(1024*1024)
+
+bootstrapped_modules() = begin
+    julia = Base.julia_cmd().exec[1]
+    mods = readlines(`$julia --startup-file=no -e "foreach(println,names(Main))"`)
+    filter!(x->x ∉ ["Base","Main"],mods)
+    mods
+end
+
+write_blacklist(modules) = begin
+    open(sysimg_folder("blacklist.txt"),"w") do io
+        foreach(modules) do s
+            println(io,s)
+        end
+    end
+end
+"""
+    blacklist(modules...)
+
+blacklists zero or more modules from being precompiled when bootstrapping
+using `bootstrap(;force = true)`.  if a module is imported in
+some other module then that module should be blacklisted too.The blacklist
+is persistant.
+
+
+returns: a list of all blacklisted modules
+"""
+blacklist(modules...) = begin
+    blkl = open(x->x |> seekstart |> readlines,sysimg_folder("blacklist.txt"),"a+")
+    length(modules) == 0 && return blkl
+    bmods = bootstrapped_modules()
+    foreach(modules) do s
+        (s in bmods) && warn("Symbol $s is blacklisted but it is already bootstrapped,\nupdates to $s will not be visible! run `bootstrap(;force = true)` again")
+    end
+    blkl = unique(append!(blkl,modules))
+    write_blacklist(blkl)
+    blkl
+end
+export blacklist
+
+"""
+    whitelist(modules...)
+
+remove one or more modules from the persistant blacklist
+"""
+whitelist(modules...) = begin
+    blkl = blacklist()
+    filter!(s -> s ∉ modules,blkl)
+    write_blacklist(blkl)
+    blkl
+end
+export whitelist

--- a/src/bootstrapping.jl
+++ b/src/bootstrapping.jl
@@ -1,0 +1,82 @@
+
+bootstrap_fid = nothing
+function log_bootstrap(discard_last_session = false)
+    stop_log_bootstrap()
+    mod = discard_last_session ? "w" : "a+"
+    global bootstrap_fid = open(sysimg_folder("bootstrap.csv"),mod)
+    ccall(:jl_dump_compiles, Void, (Ptr{Void},), bootstrap_fid.handle)
+end
+
+function stop_log_bootstrap()
+    global bootstrap_fid
+    (bootstrap_fid != nothing) && close(bootstrap_fid)
+    bootstrap_fid = nothing
+end
+
+function bootstrap(;vanilla = false, force = false)
+    generate_bootstrap_jl()
+    bootstrap(sysimg_folder("bootstrap.jl"); vanilla = vanilla, force = force)
+end
+
+function bootstrap(bootstrap_jl::String;vanilla = false, force = false)
+    start_path = pwd()
+    image_path = sysimg_folder()
+    if vanilla
+        build_sysimg(image_path, bootstrap_jl)
+    else
+        build_sysimg(image_path, bootstrap_jl;sysimg = nothing)
+    end
+
+    sys_o = "sys.$(Libdl.dlext)"
+    source = sysimg_folder(sys_o)
+    dest = joinpath(default_sysimg_path(),sys_o)
+    try
+        !force && throw(ErrorException("force flag set to false"))
+        cp(source,dest;remove_destination=true)
+        info("Succesfuly bootsrapped and replaced $dest")
+    catch err
+        warn(err)
+        info("try manually copying using\n cp $source $dest")
+    end
+    cd(start_path)
+    log_bootstrap(true)
+end
+
+parseable(ln) = try parse(ln);true;catch false; end
+function generate_bootstrap_jl()
+    stop_log_bootstrap()
+    pc = SnoopCompile.read(sysimg_folder("bootstrap.csv"))[2]
+    pc =  SnoopCompile.parcel(pc;blacklist = ["Main"])
+    blacklist = [:PackageCompiler,:unknown,:Main]
+    open(sysimg_folder("bootstrap.jl"), "w") do io
+        println(io,"try JULIA_HOME;catch Sys.__init__();Base.early_init();end")
+
+        for (k,v) in pc
+            k in blacklist && continue
+            println(io,"println(\"precompiling $k\")")
+            println(io,"try\n   import $k")
+            foreach(unique(v)) do ln
+                parseable(ln) && println(io,try_catch_string_tabbed(ln;tabs=1))
+            end
+            println(io,"catch err\n   warn(err)\nend")
+            println(io,"println(\"$k DONE!\")")
+        end
+
+        v_unknown = get!(pc,:unknown,String[])
+        foreach(unique(v_unknown)) do ln
+            parseable(ln) && println(io,try_catch_string_tabbed(ln))
+        end
+
+    end
+end
+
+try_catch_string_tabbed(ln::String;tabs = 0) = begin
+    ts = "   "^tabs
+    string(ts*"try\n   ",
+                ts*ln,"\n",
+            ts*"catch err\n   ",
+                ts*"println(STDERR,\"\"\"Failed: [$(ln)\"\"\")\n",
+            ts*"end")
+end
+
+sys_size_MB() = stat(joinpath(default_sysimg_path(),"sys.$(Libdl.dlext)")).size/(1024*1024)

--- a/src/static_julia.jl
+++ b/src/static_julia.jl
@@ -169,14 +169,15 @@ function build_julia_cmd(
     push!(julia_cmd.exec, string("--startup-file=", startupfile ? "yes" : "no"))
     compile == nothing || (julia_cmd.exec[4] = "--compile=$compile")
     cpu_target == nothing || (julia_cmd.exec[2] = "-C$cpu_target";)
-    optimize == nothing || push!(julia_cmd.exec, "-O$optimize")
+    push!(julia_cmd.exec, "-O3")
     debug == nothing || push!(julia_cmd.exec, "-g$debug")
     inline == nothing || push!(julia_cmd.exec, "--inline=$inline")
     check_bounds == nothing || push!(julia_cmd.exec, "--check-bounds=$check_bounds")
     math_mode == nothing || push!(julia_cmd.exec, "--math-mode=$math_mode")
     depwarn == nothing || (julia_cmd.exec[5] = "--depwarn=$depwarn")
-    push!(julia_cmd.exec, "--precompiled=no");
+    push!(julia_cmd.exec, "--precompiled=yes")
     push!(julia_cmd.exec, "--compilecache=no")
+    push!(julia_cmd.exec, "--history-file=no")
     julia_cmd
 end
 
@@ -206,10 +207,7 @@ function build_object(
         empty!(Base.LOAD_CACHE_PATH) # reset / remove build-system-relative paths"
     end
     isdir(builddir) || mkpath(builddir)
-    command = `$julia_cmd -e $expr`
-    verbose && println("Build module image files \".ji\" in directory \"$builddir\":\n  $command")
-    run(command)
-    command = `$julia_cmd --output-o $(joinpath(builddir, o_file)) -e $expr`
+    command = `$julia_cmd  --output-o $(joinpath(builddir, o_file)) -e $expr`
     verbose && println("Build object file \"$o_file\" in directory \"$builddir\":\n  $command")
     run(command)
 end

--- a/src/system_image.jl
+++ b/src/system_image.jl
@@ -32,13 +32,13 @@ function compile_system_image(sysimg_path, cpu_target = nothing; debug = false)
         # Start by building inference.{ji,o}
         inference_path = joinpath(dirname(sysimg_path), "inference")
         info("Building inference.o")
-        info("$julia -C $cpu_target --output-ji $inference_path.ji --output-o $inference_path.o coreimg.jl")
-        run(`$julia -C $cpu_target --output-ji $inference_path.ji --output-o $inference_path.o coreimg.jl`)
+        info("$julia -O3 -C $cpu_target --output-ji $inference_path.ji --output-o $inference_path.o coreimg.jl")
+        run(`$julia -O3 -C $cpu_target --output-ji $inference_path.ji --output-o $inference_path.o coreimg.jl`)
 
         # Bootstrap off of that to create sys.{ji,o}
         info("Building sys.o")
-        info("$julia -C $cpu_target --output-ji $sysimg_path.ji --output-o $sysimg_path.o -J $inference_path.ji --startup-file=no sysimg.jl")
-        run(`$julia -C $cpu_target --output-ji $sysimg_path.ji --output-o $sysimg_path.o -J $inference_path.ji --startup-file=no sysimg.jl`)
+        info("$julia -O3 -C $cpu_target --output-ji $sysimg_path.ji --output-o $sysimg_path.o -J $inference_path.ji --startup-file=no sysimg.jl")
+        run(`$julia -O3 -C $cpu_target --output-ji $sysimg_path.ji --output-o $sysimg_path.o -J $inference_path.ji --startup-file=no sysimg.jl`)
 
         build_shared(
             "$sysimg_path.$(Libdl.dlext)", "$sysimg_path.o",


### PR DESCRIPTION
This PR adds several commands to the PackageCompiler
"""
    log_bootstrap(discard_last_session = false)

starts logging every function that is being compiled, to be later bootstrapped on top
of the existing sysimg `bootstrap(;force = true)`


`log_bootstrap(true)` erases previously logged function list

"""

"""
    bootstrap(;vanilla = false, force = false)

bootstraps a precompilation file for all methods logged using `log_bootstrap()`.
if your development code is in a module that is discoverable without any modification to
`LOAD_PATH` then it should be blacklisted `blacklist(modname)` along with
any discoverable module that imports it. otherwise changes to it will not be visible once it is bootstrapped .
bootstrapping clears the logged file,
bootstrapping can be repeated and it is cumulative

"""

"""
    bootstrap(bootstrap_jl::String;vanilla = false, force = false)

bootstraps `bootstrap_jl` to the sysimg, so that at startup `julia` is in the
state as if `include(bootstrap_jl)` has already been executed.


set `force=true`
to copy over the new sysimg, or follow the instruction at the end to do it manually.
set `vanilla = true` to bootstrap over a clean sysimg in case the current sysimg is
already a bootstraped one , and you wish to start from start

"""


I work out of the package system, that is all the modules I personally develop are not discoverable without first adding their path to the LOAD_PATH. 
I added these lines to .juliarc
```

try
    import PackageCompiler
    PackageCompiler.log_bootstrap()
catch err
    warn(err)
end
```

so it logs all functions including Atom and Juno and what not, the result after several times running
bootstrap(;force = true) is an amazingly pleasant and responsive system .. almost **miraculous** :-)

I added a persistent blacklist to assist people who work within the packages directory

"""
    blacklist(modules...)

blacklists zero or more modules from being precompiled when bootstrapping
using `bootstrap(;force = true)`.  if a module is imported in
some other module then that module should be blacklisted too.The blacklist
is persistant.


returns: a list of all blacklisted modules
"""


"""
    whitelist(modules...)

remove one or more modules from the persistant blacklist
"""


