### PR TITLE
Keep `builddir` relative to user's cwd.

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,9 +76,7 @@ positional arguments:
   cprog                 C program to compile (required only when
                         building an executable; if not provided a
                         minimal driver program is used)
-  builddir              directory used for building, either absolute
-                        or relative to the Julia program directory
-                        (default: "builddir")
+  builddir              build directory (default: "builddir")
 
 optional arguments:
   -v, --verbose         increase verbosity

--- a/src/static_julia.jl
+++ b/src/static_julia.jl
@@ -59,7 +59,8 @@ compiles the Julia file at path `juliaprog` with keyword arguments:
 """
 function static_julia(
         juliaprog;
-        cprog = nothing, builddir = "builddir", juliaprog_basename = splitext(basename(juliaprog))[1],
+        cprog = nothing, juliaprog_basename = splitext(basename(juliaprog))[1],
+        builddir = "$juliaprog_basename/builddir",
         verbose = false, quiet = false, clean = false,
         autodeps = false, object = false, shared = false, executable = false, julialibs = false,
     	sysimage = nothing, compile = nothing, cpu_target = nothing,
@@ -84,9 +85,9 @@ function static_julia(
         quiet || println("C program file:\n  \"$cprog\"")
     end
 
+    builddir = abspath(builddir)
     cd(dirname(juliaprog))
 
-    builddir = abspath(builddir)
     quiet || println("Build directory:\n  \"$builddir\"")
 
     if !any([clean, object, shared, executable, julialibs])

--- a/src/static_julia.jl
+++ b/src/static_julia.jl
@@ -31,7 +31,7 @@ end
 compiles the Julia file at path `juliaprog` with keyword arguments:
 
     cprog = nothing           C program to compile (required only when building an executable; if not provided a minimal driver program is used)
-    builddir = "builddir"     directory used for building, either absolute or relative to the Julia program directory (default: "builddir")
+    builddir = "builddir"     directory used for building, either absolute or relative to `cwd` (default: "builddir")
     juliaprog_basename        basename for the built artifacts
 
     verbose                   increase verbosity
@@ -60,7 +60,7 @@ compiles the Julia file at path `juliaprog` with keyword arguments:
 function static_julia(
         juliaprog;
         cprog = nothing, juliaprog_basename = splitext(basename(juliaprog))[1],
-        builddir = "$juliaprog_basename/builddir",
+        builddir = "builddir",
         verbose = false, quiet = false, clean = false,
         autodeps = false, object = false, shared = false, executable = false, julialibs = false,
     	sysimage = nothing, compile = nothing, cpu_target = nothing,

--- a/src/static_julia.jl
+++ b/src/static_julia.jl
@@ -31,7 +31,7 @@ end
 compiles the Julia file at path `juliaprog` with keyword arguments:
 
     cprog = nothing           C program to compile (required only when building an executable; if not provided a minimal driver program is used)
-    builddir = "builddir"     directory used for building (default: "builddir")
+    builddir = "builddir"     building directory (default: "builddir")
     juliaprog_basename        basename for the built artifacts
 
     verbose                   increase verbosity

--- a/src/static_julia.jl
+++ b/src/static_julia.jl
@@ -31,7 +31,7 @@ end
 compiles the Julia file at path `juliaprog` with keyword arguments:
 
     cprog = nothing           C program to compile (required only when building an executable; if not provided a minimal driver program is used)
-    builddir = "builddir"     building directory (default: "builddir")
+    builddir = "builddir"     build directory (default: "builddir")
     juliaprog_basename        basename for the built artifacts
 
     verbose                   increase verbosity

--- a/src/static_julia.jl
+++ b/src/static_julia.jl
@@ -31,7 +31,7 @@ end
 compiles the Julia file at path `juliaprog` with keyword arguments:
 
     cprog = nothing           C program to compile (required only when building an executable; if not provided a minimal driver program is used)
-    builddir = "builddir"     directory used for building, either absolute or relative to `cwd` (default: "builddir")
+    builddir = "builddir"     directory used for building (default: "builddir")
     juliaprog_basename        basename for the built artifacts
 
     verbose                   increase verbosity
@@ -59,8 +59,7 @@ compiles the Julia file at path `juliaprog` with keyword arguments:
 """
 function static_julia(
         juliaprog;
-        cprog = nothing, juliaprog_basename = splitext(basename(juliaprog))[1],
-        builddir = "builddir",
+        cprog = nothing, builddir = "builddir", juliaprog_basename = splitext(basename(juliaprog))[1],
         verbose = false, quiet = false, clean = false,
         autodeps = false, object = false, shared = false, executable = false, julialibs = false,
     	sysimage = nothing, compile = nothing, cpu_target = nothing,
@@ -79,6 +78,7 @@ function static_julia(
     juliaprog = abspath(juliaprog)
     isfile(juliaprog) || error("Cannot find file:\n  \"$juliaprog\"")
     quiet || println("Julia program file:\n  \"$juliaprog\"")
+
     if executable
         cprog = cprog == nothing ? joinpath(@__DIR__, "..", "examples", "program.c") : abspath(cprog)
         isfile(cprog) || error("Cannot find file:\n  \"$cprog\"")
@@ -86,9 +86,9 @@ function static_julia(
     end
 
     builddir = abspath(builddir)
-    cd(dirname(juliaprog))
-
     quiet || println("Build directory:\n  \"$builddir\"")
+
+    cd(dirname(juliaprog))
 
     if !any([clean, object, shared, executable, julialibs])
         quiet || println("Nothing to do")


### PR DESCRIPTION
Before this change, a user-specified builddir would be evaluated as relative
to the juliaprog file. After this change, the builddir would be relative
to user's terminal's pwd.

Example:

```
$ cd ~/myApp
$ julia ~/.julia/v0.6/PackageCompiler/juliac.jl -vaej test/mytest.jl ~/.julia/v0.6/PackageCompiler/examples/program.c build
```

Before:
build directory = `~/myApp/test/build/mytest`
After:
build directory = `~/myApp/build/mytest`

--------------

If builddir is not specified, this commit will keep the default builddir the
same: `"$(dirname($juliaprog))/$builddir"`