### PR TITLE
Reenable `--precompiled=yes` module optimization.

### DIFF
--- a/src/static_julia.jl
+++ b/src/static_julia.jl
@@ -172,14 +172,14 @@ function build_julia_cmd(
     sysimage == nothing || (julia_cmd.exec[3] = "-J$sysimage")
     push!(julia_cmd.exec, string("--startup-file=", startupfile ? "yes" : "no"))
     compile == nothing || (julia_cmd.exec[4] = "--compile=$compile")
-    cpu_target == nothing || (julia_cmd.exec[2] = "-C$cpu_target";)
+    cpu_target == nothing || (julia_cmd.exec[2] = "-C$cpu_target";
+                              push!(julia_cmd.exec, "--precompiled=no"))
     optimize == nothing || push!(julia_cmd.exec, "-O$optimize")
     debug == nothing || push!(julia_cmd.exec, "-g$debug")
     inline == nothing || push!(julia_cmd.exec, "--inline=$inline")
     check_bounds == nothing || push!(julia_cmd.exec, "--check-bounds=$check_bounds")
     math_mode == nothing || push!(julia_cmd.exec, "--math-mode=$math_mode")
     depwarn == nothing || (julia_cmd.exec[5] = "--depwarn=$depwarn")
-    push!(julia_cmd.exec, "--precompiled=no");
     push!(julia_cmd.exec, "--compilecache=no")
     julia_cmd
 end


### PR DESCRIPTION
`--compilecache` and `--precompiled` were originally disabled to fix a
segfault, but only disabling `--compilecache` is sufficient to fix that
problem. This PR reenables `--precompiled=yes` as long as the build
is not using a custom `cpu_target`.

See this discussion for more details:
https://github.com/JuliaLang/PackageCompiler.jl/issues/47#issuecomment-379528765