### PR TITLE
Fix JULIA_HOME manually for all builds.

### DIFF
--- a/src/static_julia.jl
+++ b/src/static_julia.jl
@@ -206,6 +206,7 @@ function build_object(
         iswindows() && (juliaprog = replace(juliaprog, "\\", "\\\\"))
         expr = "empty!(Base.LOAD_CACHE_PATH) # reset / remove any builtin paths
         push!(Base.LOAD_CACHE_PATH, abspath(\"$builddir_esc\")) # enable usage of precompiled files
+        Sys.__init__(); Base.early_init(); # JULIA_HOME is not defined, initializing manually
         include(\"$juliaprog\") # include Julia program file
         empty!(Base.LOAD_CACHE_PATH) # reset / remove build-system-relative paths"
     end


### PR DESCRIPTION
Add calls to manually initialize `JULIA_HOME` per discussion in #47.
After this change, users shouldn't have to worry about setting
JULIA_HOME manually themselves.