### PR TITLE
Set PROGRAM_FILE global via `argv[0]`.

### DIFF
--- a/examples/program.c
+++ b/examples/program.c
@@ -21,24 +21,32 @@ int main(int argc, char *argv[])
     int retcode;
     int i;
     uv_setup_args(argc, argv); // no-op on Windows
+
     // initialization
     libsupport_init();
+
     // jl_options.compile_enabled = JL_OPTIONS_COMPILE_OFF;
     // JULIAC_PROGRAM_LIBNAME defined on command-line for compilation
     jl_options.image_file = JULIAC_PROGRAM_LIBNAME;
     julia_init(JL_IMAGE_JULIA_HOME);
 
-    // build arguments array: `String[ unsafe_string(argv[i]) for i in 1:argc ]`
-    jl_array_t *ARGS = jl_alloc_array_1d(jl_apply_array_type(jl_string_type, 1), 0);
-    JL_GC_PUSH1(&ARGS);
+    // Initialize Core.ARGS with the full argv.
+    jl_set_ARGS(argc, argv);
+
+    // Set PROGRAM_FILE to argv[0].
+    jl_set_global(jl_base_module,
+        jl_symbol("PROGRAM_FILE"), (jl_value_t*)jl_cstr_to_string(argv[0]));
+
+    // Set Base.ARGS to `String[ unsafe_string(argv[i]) for i in 1:argc ]`
+    jl_array_t *ARGS = (jl_array_t*)jl_get_global(jl_base_module, jl_symbol("ARGS"));
     jl_array_grow_end(ARGS, argc - 1);
     for (i = 1; i < argc; i++) {
         jl_value_t *s = (jl_value_t*)jl_cstr_to_string(argv[i]);
         jl_arrayset(ARGS, s, i - 1);
     }
+
     // call the work function, and get back a value
     retcode = julia_main(ARGS);
-    JL_GC_POP();
 
     // Cleanup and gracefully exit
     jl_atexit_hook(retcode);


### PR DESCRIPTION
Changes default `program.c` to manually set `PROGRAM_FILE` via its `argv[0]`.

Ideally, I think we would also set global `ARGS`, in the same way the julia interpreter does, but I still haven't figured out how to get that to work.

For #54.