### PR TITLE
Fix path of precompiled.jl and library as included from julia_main.jl

### DIFF
--- a/src/api.jl
+++ b/src/api.jl
@@ -79,8 +79,8 @@ function build_executable(
         snoop(snoopfile, precompfile, joinpath(builddir, "snoop.csv"))
         jlmain = joinpath(builddir, "julia_main.jl")
         open(jlmain, "w") do io
-            println(io, "include(\"$(escape_string(precompfile))\")")
-            println(io, "include(\"$(escape_string(library))\")")
+            println(io, "include(\"$(escape_string(relpath(precompfile, builddir)))\")")
+            println(io, "include(\"$(escape_string(relpath(library, builddir)))\")")
         end
         library = jlmain
     end


### PR DESCRIPTION
Since `julia_main.jl` lives in `builddir`, it should include files relative to `builddir`.

Without this change, something similar to `include("builddir/precompiled.jl")` would appear in `builddir/julia_main.jl`, resulting in `ERROR: LoadError: could not open file`.