### PR TITLE
Have all static_julia apis return true on success.

### DIFF
--- a/src/api.jl
+++ b/src/api.jl
@@ -20,7 +20,7 @@ function build_sysimg(
     )
     # build vanilla backup system image
     clean_sysimg = get_backup!(contains(basename(Base.julia_cmd().exec[1]), "debug"), cpu_target)
-    static_julia(
+    return static_julia(
         userimg_path, verbose = verbose, quiet = quiet,
         builddir = sysimg_path, outname = "sys",
         autodeps = true, shared = true,
@@ -39,7 +39,7 @@ function build_shared_lib(
         compile = nothing, cpu_target = nothing, optimize = nothing, debug = nothing,
         inline = nothing, check_bounds = nothing, math_mode = nothing, depwarn = nothing
     )
-    static_julia(
+    return static_julia(
         library, verbose = verbose, quiet = quiet,
         builddir = sysimg_path, outname = library_name,
         autodeps = true, shared = true, julialibs = true,
@@ -84,7 +84,7 @@ function build_executable(
         end
         library = jlmain
     end
-    static_julia(
+    return static_julia(
         library, cprog = cprog, verbose = verbose, quiet = quiet,
         builddir = builddir, outname = library_name,
         autodeps = true, executable = true, julialibs = true,

--- a/src/static_julia.jl
+++ b/src/static_julia.jl
@@ -68,7 +68,7 @@ function static_julia(
         compile = nothing, cpu_target = nothing, optimize = nothing, debug = nothing,
         inline = nothing, check_bounds = nothing, math_mode = nothing, depwarn = nothing,
         cc = system_compiler, cc_flags = nothing
-    )
+    )::Bool
 
     verbose && quiet && (quiet = false)
 
@@ -106,7 +106,7 @@ function static_julia(
 
     if !any([object, shared, executable, rmtemp, julialibs])
         quiet || println("All done")
-        return
+        return true
     end
 
     if !isdir(builddir)
@@ -133,6 +133,8 @@ function static_julia(
     julialibs && copy_julia_libs(builddir, verbose)
 
     quiet || println("All done")
+
+    return true
 end
 
 # TODO: avoid calling "julia-config.jl" in future

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -35,7 +35,7 @@ end
             println(io)
             println(io, "using .Hello; Hello.julia_main(String[])")
         end
-        build_executable(
+        @test build_executable(
             jlfile, snoopfile = snoopfile, builddir = relativebuilddir, verbose = true
         )
     end


### PR DESCRIPTION
Change `build_sysimg`, `build_shared_lib`, and `build_executable` to
return `true` on success to allow `&&` chaining them with other commands
e.g., this used to fail:
julia> build_executable("test.jl")) && run("./builddir/test")
...
ERROR: TypeError: non-boolean (Void) used in boolean context