### PR TITLE
Get `static_julia` working for simple files on julia v0.7!

### DIFF
--- a/src/static_julia.jl
+++ b/src/static_julia.jl
@@ -203,17 +203,15 @@ function build_object(
         expr = "
   Base.init_depot_path() # initialize package depots
   Base.init_load_path() # initialize location of site-packages
-  empty!(Base.DEPOT_PATH) # reset / remove any builtin paths
-  push!(Base.DEPOT_PATH, \"$cache_dir\") # enable usage of precompiled files
-  include(\"$juliaprog\") # include Julia program file
-  empty!(Base.DEPOT_PATH) # reset / remove build-system-relative paths"
+  Sys.__init__();  # Needed to find built-in Modules.
+  include(\"$juliaprog\") # include Julia program file"
     else
         expr = "
   empty!(Base.LOAD_CACHE_PATH) # reset / remove any builtin paths
   push!(Base.LOAD_CACHE_PATH, \"$cache_dir\") # enable usage of precompiled files
   Sys.__init__(); Base.early_init(); # JULIA_HOME is not defined, initializing manually
-  include(\"$juliaprog\") # include Julia program file
-  empty!(Base.LOAD_CACHE_PATH) # reset / remove build-system-relative paths"
+  include(\"$juliaprog\") # include julia program file
+  empty!(base.LOAD_CACHE_PATH) # reset / remove build-system-relative paths"
     end
     if compilecache == "yes"
         command = `$julia_cmd -e $expr`

--- a/src/static_julia.jl
+++ b/src/static_julia.jl
@@ -204,14 +204,15 @@ function build_object(
   Base.init_depot_path() # initialize package depots
   Base.init_load_path() # initialize location of site-packages
   Sys.__init__();  # Needed to find built-in Modules.
+  Base.__init__();
   include(\"$juliaprog\") # include Julia program file"
     else
         expr = "
   empty!(Base.LOAD_CACHE_PATH) # reset / remove any builtin paths
   push!(Base.LOAD_CACHE_PATH, \"$cache_dir\") # enable usage of precompiled files
   Sys.__init__(); Base.early_init(); # JULIA_HOME is not defined, initializing manually
-  include(\"$juliaprog\") # include julia program file
-  empty!(base.LOAD_CACHE_PATH) # reset / remove build-system-relative paths"
+  include(\"$juliaprog\") # include Julia program file
+  empty!(Base.LOAD_CACHE_PATH) # reset / remove build-system-relative paths"
     end
     if compilecache == "yes"
         command = `$julia_cmd -e $expr`

--- a/src/static_julia.jl
+++ b/src/static_julia.jl
@@ -114,7 +114,7 @@ function static_julia(
         mkpath(builddir)
     end
 
-    o_file = joinpath(builddir, outname * ".o")
+    o_file = joinpath(builddir, outname * (julia_v07 ? ".a" : ".o"))
     s_file = joinpath(builddir, outname * ".$(Libdl.dlext)")
     e_file = joinpath(builddir, outname * executable_ext)
 
@@ -232,6 +232,8 @@ function build_shared(s_file, o_file, verbose, optimize, debug, cc, cc_flags)
     elseif iswindows()
         command = `$command -Wl,--export-all-symbols`
     end
+    # Prevent compiler from stripping all symbols from the shared lib.
+    julia_v07 && (command = `$command -Wl,-all_load`)
     verbose && println("Build shared library \"$s_file\":\n  $command")
     run(command)
 end

--- a/src/static_julia.jl
+++ b/src/static_julia.jl
@@ -203,10 +203,10 @@ function build_object(
         expr = "
   Base.init_depot_path() # initialize package depots
   Base.init_load_path() # initialize location of site-packages
-  empty!(Base.LOAD_CACHE_PATH) # reset / remove any builtin paths
-  push!(Base.LOAD_CACHE_PATH, \"$cache_dir\") # enable usage of precompiled files
+  empty!(Base.DEPOT_PATH) # reset / remove any builtin paths
+  push!(Base.DEPOT_PATH, \"$cache_dir\") # enable usage of precompiled files
   include(\"$juliaprog\") # include Julia program file
-  empty!(Base.LOAD_CACHE_PATH) # reset / remove build-system-relative paths"
+  empty!(Base.DEPOT_PATH) # reset / remove build-system-relative paths"
     else
         expr = "
   empty!(Base.LOAD_CACHE_PATH) # reset / remove any builtin paths

--- a/src/static_julia.jl
+++ b/src/static_julia.jl
@@ -232,7 +232,7 @@ function build_shared(s_file, o_file, verbose, optimize, debug, cc, cc_flags)
         command = `$command -Wl,--export-all-symbols`
     end
     # Prevent compiler from stripping all symbols from the shared lib.
-    julia_v07 && (command = `$command -Wl,-all_load`)
+    julia_v07 && (command = `$command -Wl,-$(isapple() ? "all_load" : "whole-archive")`)
     verbose && println("Build shared library \"$s_file\":\n  $command")
     run(command)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -72,13 +72,13 @@ end
         )
         # Check that the output from the program is as expected:
         exe = joinpath(builddir, outname*executable_ext)
-        if julia_v07
+        if PackageCompiler.julia_v07
             output = read(`$exe a b c`, String)
         else
             output = readstring(`$exe a b c`)
         end
         println(output)
-        if julia_v07
+        if PackageCompiler.julia_v07
             @test all(s->occursin(s, output), [
                     "@__FILE__: " * argsjlfile
                     "PROGRAM_FILE: " * exe
@@ -118,13 +118,13 @@ end
         @testset "--cc-flags" begin
             # Try passing `--help` to $cc. This should work for any system compiler.
             # Then grep the output for "-g", which should be present on any system.
-            if julia_v07
+            if PackageCompiler.julia_v07
                 @test occursin("-g", read(`$julia $juliac -se --cc-flags="--help" $jlfile $cfile --builddir $builddir`, String))
             else
                 @test contains(readstring(`$julia $juliac -se --cc-flags="--help" $jlfile $cfile --builddir $builddir`), "-g")
             end
             # Just as a control, make sure that without passing '--help', we don't see "-g"
-            if julia_v07
+            if PackageCompiler.julia_v07
                 @test !occursin("-g", read(`$julia $juliac -se $jlfile $cfile --builddir $builddir`, String))
             else
                 @test !contains(readstring(`$julia $juliac -se $jlfile $cfile --builddir $builddir`), "-g")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -72,16 +72,16 @@ end
         )
         # Check that the output from the program is as expected:
         exe = joinpath(builddir, outname*executable_ext)
-        output = readstring(`$exe a b c`)
+        output = read(`$exe a b c`, String)
         println(output)
-        @test all(s->contains(output, s), [
+        @test all(s->occursin(s, output), [
                 "@__FILE__: " * argsjlfile
                 "PROGRAM_FILE: " * exe
-                """argv: String["a", "b", "c"]"""
-                """ARGS: String["a", "b", "c"]"""
-                """Base.ARGS: String["a", "b", "c"]"""
-                # This one is a regex because it's difficult to correctly match
-                # both the unix and windows outputs.
+                # These are regexes b/c output is different on v0.6 and v0.7.
+                # All we really want to test is that it has the right args.
+                r"argv: .*[\"a\", \"b\", \"c\"]"
+                r"ARGS: .*[\"a\", \"b\", \"c\"]"
+                r"Base.ARGS: .*[\"a\", \"b\", \"c\"]"
                 r"Core.ARGS: .*[\".*builddir.*outname.*\", \"a\", \"b\", \"c\"]"
             ]
         )
@@ -100,9 +100,9 @@ end
         @testset "--cc-flags" begin
             # Try passing `--help` to $cc. This should work for any system compiler.
             # Then grep the output for "-g", which should be present on any system.
-            @test contains(readstring(`$julia $juliac -se --cc-flags="--help" $jlfile $cfile --builddir $builddir`), "-g")
+            @test occursin("-g", read(`$julia $juliac -se --cc-flags="--help" $jlfile $cfile --builddir $builddir`, String))
             # Just as a control, make sure that without passing '--help', we don't see "-g"
-            @test !contains(readstring(`$julia $juliac -se $jlfile $cfile --builddir $builddir`), "-g")
+            @test !occursin("-g", read(`$julia $juliac -se $jlfile $cfile --builddir $builddir`, String))
         end
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -44,7 +44,7 @@ end
     @test isfile(joinpath(builddir, "hello$executable_ext"))
     @test success(`$(joinpath(builddir, "hello$executable_ext"))`)
     for i = 1:100
-        try rm(basedir, recursive = true) end
+        try rm(basedir, recursive = true) catch end
         sleep(1/100)
     end
 end


### PR DESCRIPTION
This PR improves `julia v0.7` compatibility for `static_julia`.

~It builds`examples/hello.jl` successfully, and a few other examples I've tried.~

EDIT: no it doesn't, I don't know why I thought that. 😊