### PR TITLE
fix try/catch syntax for 1.0

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,6 +1,7 @@
 function verify_gcc(gcc)
     try # success errors when not successful :(
         return success(`$gcc --version`)
+    catch
     end
     return false
 end

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,9 +1,9 @@
 function verify_gcc(gcc)
-    try # success errors when not successful :(
+    try
         return success(`$gcc --version`)
     catch
+        return false
     end
-    return false
 end
 
 # TODO: remove once Julia v0.7 is released


### PR DESCRIPTION
Before these changes, installing with "add PackageCompiler" with the new package manager produces this error:

┌ Error: Error building `PackageCompiler`: 
│ ERROR: LoadError: syntax: try without catch or finally
│ Stacktrace:
│  [1] include at ./boot.jl:317 [inlined]
│  [2] include_relative(::Module, ::String) at ./loading.jl:1038
│  [3] include(::Module, ::String) at ./sysimg.jl:29
│  [4] include(::String) at ./client.jl:388
│  [5] top-level scope at none:0
│ in expression starting at /home/nstier/.julia/packages/PackageCompiler/5u3Km/deps/build.jl:4
