### PR TITLE
Add note to start of the README: 0.7 isn't supported yet

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # PackageCompiler
-[![Build Status](https://travis-ci.org/JuliaLang/PackageCompiler.jl.svg?branch=master)](https://travis-ci.org/JuliaLang/PackageCompiler.jl)
+`julia v0.6`: [![Build Status](https://travis-ci.org/JuliaLang/PackageCompiler.jl.svg?branch=master)](https://travis-ci.org/JuliaLang/PackageCompiler.jl)
+<br>`julia v0.7+`: partial support, work in progress.
 
 [![Coverage Status](https://coveralls.io/repos/JuliaLang/PackageCompiler.jl/badge.svg?branch=master&service=github)](https://coveralls.io/github/JuliaLang/PackageCompiler.jl?branch=master)
 


### PR DESCRIPTION
We've been seeing a lot of issues and PRs that 0.7/1.0 aren't working (#109, #111, #112, #113, #114, #115, #119) so i think we should add a note to the README that it's not yet supported, but it's a work in progress.

If you want, we can also link to the actual WIP PRs in the README, which might be a good idea as well.