### PR TITLE
shared_init option to export jl_runtime initialization into shared lib

### DIFF
--- a/juliac.jl
+++ b/juliac.jl
@@ -44,6 +44,9 @@ Base.@ccallable function julia_main(args::Vector{String})::Cint
         "--shared", "-s"
             action = :store_true
             help = "build shared library"
+        "--shared-init", "-i"
+            action = :store_true
+            help = "build shared library including jl_runtime initialization"
         "--executable", "-e"
             action = :store_true
             help = "build executable file"
@@ -156,7 +159,7 @@ Base.@ccallable function julia_main(args::Vector{String})::Cint
     parsed_args["copy-files"] == String[] && (parsed_args["copy-files"] = nothing)
 
     # TODO: in future it may be possible to broadcast dictionary indexing, see: https://discourse.julialang.org/t/accessing-multiple-values-of-a-dictionary/8648
-    if getindex.(Ref(parsed_args), ["clean", "object", "shared", "executable", "rmtemp", "copy-julialibs", "copy-files", "Release"]) == [false, false, false, false, false, false, nothing, false]
+    if getindex.(Ref(parsed_args), ["clean", "object", "shared", "shared-init", "executable", "rmtemp", "copy-julialibs", "copy-files", "Release"]) == [false, false, false, false, false, false, false, nothing, false]
         parsed_args["quiet"] || println("nothing to do, exiting\ntry \"$(basename(@__FILE__)) -h\" for more information")
         exit(0)
     end

--- a/src/api.jl
+++ b/src/api.jl
@@ -56,7 +56,7 @@ function build_shared_lib(
         home = nothing, startup_file = nothing, handle_signals = nothing,
         compile = nothing, cpu_target = nothing, optimize = nothing, debug = nothing,
         inline = nothing, check_bounds = nothing, math_mode = nothing, depwarn = nothing,
-        cc = nothing, cc_flags = nothing
+        cc = nothing, cc_flags = nothing, shared_init = false
     )
     static_julia(
         julia_program, verbose = verbose, quiet = quiet,
@@ -66,7 +66,7 @@ function build_shared_lib(
         home = home, startup_file = startup_file, handle_signals = handle_signals,
         compile = compile, cpu_target = cpu_target, optimize = optimize, debug = debug,
         inline = inline, check_bounds = check_bounds, math_mode = math_mode, depwarn = depwarn,
-        cc = cc, cc_flags = cc_flags
+        cc = cc, cc_flags = cc_flags, shared_init = shared_init
     )
 end
 

--- a/src/static_julia.jl
+++ b/src/static_julia.jl
@@ -255,7 +255,7 @@ end
 
 function build_shared(s_file, o_file, builddir, verbose, optimize, debug, cc, cc_flags, shared_init)
     # Prevent compiler from stripping all symbols from the shared lib.
-    si_file = nothing
+    si_file = ""
     if shared_init
         si_file = joinpath(builddir, "lib_init.c")
         open(si_file, "w") do io
@@ -293,7 +293,8 @@ function build_shared(s_file, o_file, builddir, verbose, optimize, debug, cc, cc
             o_file = `-Wl,--whole-archive $o_file -Wl,--no-whole-archive`
         end
     end
-    command = `$cc -shared -DJULIAC_PROGRAM_LIBNAME=\"$s_file\" -o $s_file $o_file $si_file $(julia_flags(optimize, debug, cc_flags))`
+    command = shared_init ? `$cc -shared -DJULIAC_PROGRAM_LIBNAME=\"$s_file\" -o $s_file $o_file $si_file $(julia_flags(optimize, debug, cc_flags))` :
+        `$cc -shared -DJULIAC_PROGRAM_LIBNAME=\"$s_file\" -o $s_file $o_file $(julia_flags(optimize, debug, cc_flags))`
     if isapple()
         command = `$command -Wl,-install_name,@rpath/$s_file`
     elseif iswindows()

--- a/src/system_image.jl
+++ b/src/system_image.jl
@@ -50,7 +50,7 @@ function compile_system_image(sysimg_path, cpu_target = nothing; debug = false)
 
         build_shared(
             "$sysimg_path.$(Libdl.dlext)", "$sysimg_path.o", ".",
-            true, nothing, debug ? 2 : nothing, cc, nothing
+            true, nothing, debug ? 2 : nothing, cc, nothing, false
         )
     end
 end


### PR DESCRIPTION
A shared lib (DLL) produced by static compilation still requires some non-trivial housekeeping in order to safely use the `base.@ccallable` exported functions. Not that terrible when dealing with C++, but a very unsatisfying experience when dealing with C# (as in my case).
Therefore I've integrated into the shared library build a minimal C program that implements init_jl_runtime and exit_jl_runtime functions, so in order to use the shared library one doesn't need anything else but these two functions and his own exported functions.