### PR TITLE
Fix a typo: JULIAC_PROGRAMLIBNAME

### DIFF
--- a/src/static_julia.jl
+++ b/src/static_julia.jl
@@ -273,7 +273,7 @@ function build_shared(s_file, o_file, init_shared, builddir, verbose, optimize, 
 		void init_jl_runtime() // alternate name for jl_init_with_image, with hardcoded library name
 		{
 		    // JULIAC_PROGRAM_LIBNAME defined on command-line for compilation
-		    const char rel_libname[] = JULIAC_PROGRAMLIBNAME;
+		    const char rel_libname[] = JULIAC_PROGRAM_LIBNAME;
 		    jl_init_with_image(NULL, rel_libname);
 		}
 		void exit_jl_runtime(int retcode) // alternate name for jl_atexit_hook


### PR DESCRIPTION
Otherwise compiling with `--init-shared` fails so I guess it is a typo?

BTW, I needed to pass the full path to .so file to `jl_init_with_image` for this example to work: https://discourse.julialang.org/t/aot-compiling-using-packagecompiler/16911/5  It would be nice if `init_jl_runtime` handles such case appropriately (e.g., locate the path using dladdr?).
