### PR TITLE
Display the broken julia_cmd on error so the user can identify the problem

### DIFF
--- a/src/static_julia.jl
+++ b/src/static_julia.jl
@@ -106,7 +106,7 @@ function static_julia(
         isfile(juliaprog) || error("Cannot find file: \"$juliaprog\"")
         quiet || println("Julia program file:\n  \"$juliaprog\"")
     end
-    
+
     if executable
         cprog = abspath(cprog)
         isfile(cprog) || error("Cannot find file: \"$cprog\"")
@@ -212,7 +212,7 @@ function build_julia_cmd(
     startup_file == nothing && (startup_file = "no")
     julia_cmd = `$(Base.julia_cmd())`
     if length(julia_cmd.exec) != 5 || !all(startswith.(julia_cmd.exec[2:5], ["-C", "-J", "--compile", "--depwarn"]))
-        error("Unexpected format of \"Base.julia_cmd()\", you may be using an incompatible version of Julia")
+        error("Unexpected format of \"Base.julia_cmd()\", you may be using an incompatible version of Julia:\n$julia_cmd")
     end
     sysimage == nothing || (julia_cmd.exec[3] = "-J$sysimage")
     home == nothing || push!(julia_cmd.exec, "-H=$home")


### PR DESCRIPTION
It looks like PackageCompiler isn't compatible with Julia `v1.1.0`: the command-line args in `Base.julia_cmd()` have changed.

This PR is a tiny one that just helps the user see what's wrong in the output:

```julia
ERROR: LoadError: Unexpected format of "Base.julia_cmd()", you may be using an incompatible version of Julia:
`/Users/nathan.daly/src/julia_release_native/usr/bin/julia -Cnative -J/Users/nathan.daly/src/julia_release_native/usr/lib/julia/sys.dylib --check-bounds=yes -g1`
```

I'll follow up with an actual fix to the above v1.1 problem! :)