### PR TITLE
Add compile_incremental to exports

### DIFF
--- a/src/PackageCompiler.jl
+++ b/src/PackageCompiler.jl
@@ -152,6 +152,6 @@ function __init__()
     end
 end
 
-export compile_package, revert, force_native_image!, executable_ext, build_executable, build_shared_lib, static_julia
+export compile_package, revert, force_native_image!, executable_ext, build_executable, build_shared_lib, static_julia, compile_incremental
 
 end # module


### PR DESCRIPTION
Currently the function `compile_incremental` is not available through the PackageCompiler module.  This PR aims to fix that by adding it to the list of exports, as can be seen in the commit.