### PR TITLE
Test on Julia 1.1, allow failures on nightly.

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,11 +1,16 @@
 environment:
   matrix:
-  - julia_version: 1
+  - julia_version: 1.0
+  - julia_version: 1.1
   - julia_version: nightly
 
 platform:
   - x86 # 32-bit
   - x64 # 64-bit
+
+matrix:
+  allow_failures:
+  - julia_version: nightly
 
 # # Uncomment the following lines to allow failures on nightly julia
 # # (tests will run but not make your overall status red)

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,12 @@ os:
 
 julia:
   - 1.0
+  - 1.1
   - nightly
+
+matrix:
+  allow_failures:
+  - julia: nightly
 
 notifications:
   email: false


### PR DESCRIPTION
Allow failures on nightly because nightly will always be a moving target.