### PR TITLE
RFC: Pass custom snoopfile and arbitrary julia flags to compile_incremental

### DIFF
--- a/src/incremental.jl
+++ b/src/incremental.jl
@@ -74,14 +74,16 @@ end
 function compile_incremental(
         toml_path::Union{String, Nothing}, precompiles::String;
         force = false, verbose = true,
-        debug = false, cc_flags = nothing
+        debug = false, cc_flags = nothing,
+        kw...
     )
     systemp = sysimg_folder("sys.a")
     sysout = sysimg_folder("sys.$(Libdl.dlext)")
     code = PrecompileCommand(precompiles)
     run_julia(
         code, O = 3, output_o = systemp, g = 1,
-        track_allocation = "none", startup_file = "no", code_coverage = "none"
+        track_allocation = "none", startup_file = "no", code_coverage = "none";
+        kw...
     )
     build_shared(sysout, systemp, false, sysimg_folder(), verbose, "3", debug, system_compiler, cc_flags)
     curr_syso = current_systemimage()
@@ -104,7 +106,12 @@ end
     For a more explicit version of compile_incremental, see:
     `compile_incremental(toml_path::String, snoopfile::String)`
 """
-function compile_incremental(pkg::Symbol, packages::Symbol...; kw...)
-    toml, precompile = snoop_packages(pkg, packages...)
+function compile_incremental(package::Symbol, packages::Symbol...; kw...)
+    toml, precompile = snoop_packages(package, packages...)
+    compile_incremental(toml, precompile; kw...)
+end
+
+function compile_incremental(packages::Tuple{Symbol,String}...; kw...)
+    toml, precompile = snoop_packages(packages...)
     compile_incremental(toml, precompile; kw...)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -33,6 +33,19 @@ end
         @test read(cmd, String) == "Hello World!"
         pop!(Base.LOAD_PATH)
     end
+    @testset "unregistered package, user snoop file" begin
+        path = joinpath(@__DIR__, "TestPackage")
+        snoopfile = joinpath(@__DIR__, "TestPackage/test/runtests.jl")
+        push!(Base.LOAD_PATH, path)
+        syso, syso_old = PackageCompiler.compile_incremental((:TestPackage,snoopfile))
+        test_code = """
+        push!(Base.LOAD_PATH, $(repr(path)))
+        using TestPackage; TestPackage.greet()
+        """
+        cmd = PackageCompiler.julia_code_cmd(test_code, J = syso)
+        @test read(cmd, String) == "Hello World!"
+        pop!(Base.LOAD_PATH)
+    end
     @testset "FixedPointNumbers" begin
         # This is the new compile_package
         syso, syso_old = PackageCompiler.compile_incremental(:FixedPointNumbers)


### PR DESCRIPTION
Hi,
       Thanks for all the recent work on PackageCompiler! I've made a couple changes to compile_incremental that make it a bit more general and make it work smoothly for my use case. I think they could be useful to the general community so I've put them in a small PR. Of course feel free to ignore if you don't think these changes fit with the direction PackageCompiler is headed. This PR makes three changes:

1. Allow the user to pass their own "snoopfile" to `compile_incremental`. I think it makes sense to use a package's tests as the default thing to run to generate a precompile file but I don't understand why the option to use one's own snoopfile isn't there. I know I can just call `snoop` to generate a precompile file from my own snoopfile and then pass it to `compile_incremental` but then I lose the convenience of having one call to `compile_incremental` that calls `snoop_packages` and then the compilation itself all in one go.

2. Allow arbitrary keyword arguments to be passed to `compile_incremental` that just get passed straight through to `run_julia`. This allows the user pass any julia command line flags to run_julia. My main use case for this has been to compile with `--cpu-target=x86-64` so I can generate a system image that works across a cluster with heterogeneous hardware. I could just add a `cpu_target` keyword argument to `compile_incremental` but it seems convenient to allow passing whatever flags one might like, such as changing the bounds checking setting or the math-mode for example.

3. This last change is a hack but a useful hack I think. I've found that if the `Distributed` standard lib is initialized in the precompile file then compilation crashes with a `Task cannot be serialized` error. In practice this has meant that I haven't been able to compile any packages that depend on `Distributed`. However, packages that use functionality from `Distributed` can still be compiled. I had been making this work manually. For example, to compile JSON.jl I would run `compile_incremental(:JSON)`, which crashed when it ran julia with `-output-o`. I would then take a look at `.../PackageCompiler/packages/incremental_precompile.jl`, which in this example has the following lines:
```
using Pkg, Test, Distributed, FixedPointNumbers, OffsetArrays, JSON, DataStructures, Mmap, Unicode, Dates, PackageCompiler, Sockets
for Mod in [Pkg, Test, Distributed, FixedPointNumbers, OffsetArrays, JSON, DataStructures, Mmap, Unicode, Dates, PackageCompiler, Sockets]
    isdefined(Mod, :__init__) && Mod.__init__()
end
```
I would then manually edit the file to remove the references to `Distributed` from the section shown and then run `compile_incremental(nothing,".../PackageCompiler/packages/incremental_precompile.jl")`. This PR automates the removal of the references to `Distributed` by changing line 47 of snooping.jl to
```
packages = join(setdiff(used_packages,["Distributed"]), ", ")
```
This is of course a total hack but I imagine it could make a lot more packages compile-able right now.