### PR TITLE
Add support for snoopfiles in packages and blacklisting of packages

### DIFF
--- a/src/incremental.jl
+++ b/src/incremental.jl
@@ -93,18 +93,31 @@ end
     compile_incremental(
         packages::Symbol...;
         force = false, reuse = false, verbose = true,
-        debug = false, cc_flags = nothing
+        debug = false, cc_flags = nothing,
+        blacklist::Vector = []
     )
 
     Incrementally compile `package` into the current system image.
     `force = true` will replace the old system image with the new one.
-    `compile_incremental` will run the `Package/test/runtests.jl` file to
-    record the functions getting compiled. The coverage of the Package's tests will
-    thus determine what is getting ahead of time compiled.
-    For a more explicit version of compile_incremental, see:
-    `compile_incremental(toml_path::String, snoopfile::String)`
+    This process requires a script that julia will run in order to determine 
+    which functions to compile. A package may define a script called `snoopfile.jl` 
+    for this purpose. If this file cannot be found the package's test script
+    `Package/test/runtests.jl` will be used. `compile_incremental` will search 
+    for `snoopfile.jl` in the package's root directory and in the folders
+    `Package/src` and `Package/snoop`. For a more explicit version of compile_incremental, 
+    see: `compile_incremental(toml_path::String, snoopfile::String)`
+
+    Not all packages can currently be compiled into the system image. By default,
+    `compile_incremental(:Package) will also compile all of Package's dependencies.
+    It can still be desirable to compile packages with dependencies that cannot be
+    compiled. For this reason `compile_incremental` offers
+    the ability for the user to pass a list of blacklisted packages
+    that will be ignored during the compilation process. These are passed as a 
+    vector of package names (defined as either strings or symbols) using the
+    `blacklist keyword argument`    
 """
-function compile_incremental(pkg::Symbol, packages::Symbol...; kw...)
-    toml, precompile = snoop_packages(pkg, packages...)
+function compile_incremental(pkg::Symbol, packages::Symbol...;
+                             blacklist::Vector=[], kw...)
+    toml, precompile = snoop_packages(pkg, packages...; blacklist=blacklist)
     compile_incremental(toml, precompile; kw...)
 end

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,3 +1,6 @@
 ColorTypes
 FixedPointNumbers
 UnicodePlots
+JSON
+DataStructures
+OffsetArrays

--- a/test/TestPackage2/Project.toml
+++ b/test/TestPackage2/Project.toml
@@ -1,0 +1,4 @@
+name = "TestPackage2"
+uuid = "886979a0-3551-11e9-32b6-2991215e940c"
+authors = ["Patrick Belliveau <patrick@compgeoinc.com>"]
+version = "0.1.0"

--- a/test/TestPackage2/snoop/snoopfile.jl
+++ b/test/TestPackage2/snoop/snoopfile.jl
@@ -1,0 +1,3 @@
+using TestPackage2
+
+TestPackage2.greet()

--- a/test/TestPackage2/src/TestPackage2.jl
+++ b/test/TestPackage2/src/TestPackage2.jl
@@ -1,0 +1,5 @@
+module TestPackage2
+
+greet() = print("Hello World!")
+
+end # module


### PR DESCRIPTION
This supersedes #187. See discussion there for more background. Took me a little longer to get to this than I had planned but it's done now.

As per https://github.com/JuliaLang/PackageCompiler.jl/pull/187#issuecomment-463486218, this PR implements support for incremental compilation of packages using a file `snoopfile.jl` defined in the package to generate precompile statements. `runtests.jl` is used as a fallback in the case that no `snoopfile.jl` can be found. A package blacklisting feature has also been added to `compile_incremental`/the snooping code. This allows the user to pass a list of blacklisted packages to `compile_incremental`. Importing and explicit initialization of these packages will not be added to the precompile file.