### PR TITLE
Fix Regression in revert()

### DIFF
--- a/src/PackageCompiler.jl
+++ b/src/PackageCompiler.jl
@@ -44,6 +44,7 @@ Reverts a forced compilation of the system image. Calls out to
 `Main.BuildSysImg.build_sysimg(force = true)`.
 """
 function revert(debug = false)
+    include(joinpath(Sys.BINDIR, Base.DATAROOTDIR, "julia", "build_sysimg.jl"))
     Main.BuildSysImg.build_sysimg(force = true)
 end
 

--- a/src/PackageCompiler.jl
+++ b/src/PackageCompiler.jl
@@ -40,14 +40,11 @@ function julia_cpu_target(::Nothing)
 end
 
 """
-Reverts a forced compilation of the system image.
-This will restore any previously backed up system image files, or
-build a new, clean system image.
+Reverts a forced compilation of the system image. Calls out to 
+`Main.BuildSysImg.build_sysimg(force = true)`.
 """
 function revert(debug = false)
-    syspath = default_sysimg_path(debug)
-    sysimg_backup = dirname(get_backup!(debug))
-    copy_system_image(sysimg_backup, syspath)
+    Main.BuildSysImg.build_sysimg(force = true)
 end
 
 function get_root_dir(path)


### PR DESCRIPTION
@SimonDanisch I replace what we had in `revert()` (rolling our own system image using the `compile_system_image`), with the default functions coming out of the Julia `DATAROOTDIR`.

If this looks good to you (it seems to fix the regression on my machine), then I'll update the docs/propagation of the now-defunct `debug` argument. 

If you want to stick with the homegrown stuff, I can try something with `PrecompileCommand`.