### PR TITLE
Bug fix: Run Pkg.resolve() after modifying Project.toml

### DIFF
--- a/src/pkg.jl
+++ b/src/pkg.jl
@@ -154,6 +154,13 @@ function package_toml(package::Symbol)
         compile_toml["compat"] = toml["compat"]
     end
     write_toml(precompile_toml, compile_toml)
+    # Resolve the Manifest after adding the new packages to the Project
+    run_julia("""
+    using Pkg
+    Pkg.resolve()
+    Pkg.instantiate()
+    """, project = precompile_toml)
+
     precompile_toml, snoopfile
 end
 


### PR DESCRIPTION
This fixes `compile_package` and `compile_incremental` for packages that have test-only dependencies.

For example, I was seeing this error when I tried to compile `CSV`:
```
julia> PackageCompiler.compile_package("CSV", force=false)
[ Info: Recompiling stale cache file /Users/nathan.daly/.julia/compiled/v1.1/CSV/HHBkp.ji for CSV [336ed68f-0bac-5ca0-87d4-7b16caf5d00b]
[ Info: Registered package CSV, using already given UUID: 336ed68f-0bac-5ca0-87d4-7b16caf5d00b
Project CSV v0.4.3
    Status `~/.julia/dev/PackageCompiler/packages/CSV/Project.toml`
  (empty environment)
 Resolving package versions...
  Updating `~/.julia/dev/PackageCompiler/packages/CSV/Project.toml`
  [324d7699] + CategoricalArrays v0.5.2
  [a93c6f00] + DataFrames v0.17.1
  [9a8bc11e] + DataStreams v0.4.1
  [7d512f48] + InternedStrings v0.7.0
  [e1d29d7a] + Missings v0.4.0
  [ea10d353] + WeakRefStrings v0.5.8
  [ade2ca70] + Dates
  [a63ad114] + Mmap
  Updating `~/.julia/dev/PackageCompiler/packages/CSV/Manifest.toml`
  [b99e7846] + BinaryProvider v0.5.3
  [324d7699] + CategoricalArrays v0.5.2
  [944b1d66] + CodecZlib v0.5.2
  [34da2185] + Compat v2.0.0
  [a93c6f00] + DataFrames v0.17.1
  [9a8bc11e] + DataStreams v0.4.1
  [864edb3b] + DataStructures v0.15.0
  [7d512f48] + InternedStrings v0.7.0
  [82899510] + IteratorInterfaceExtensions v0.1.1
  [e1d29d7a] + Missings v0.4.0
  [bac558e1] + OrderedCollections v1.0.2
  [189a3867] + Reexport v0.2.0
  [ae029012] + Requires v0.5.2
  [a2af1166] + SortingAlgorithms v0.3.1
  [2913bbd2] + StatsBase v0.29.0
  [3783bdb8] + TableTraits v0.4.1
  [bd369af6] + Tables v0.1.18
  [3bb67fe8] + TranscodingStreams v0.9.3
  [ea10d353] + WeakRefStrings v0.5.8
  [2a0f44e3] + Base64
  [ade2ca70] + Dates
  [8bb1440f] + DelimitedFiles
  [8ba89e20] + Distributed
  [9fa8497b] + Future
  [b77e0a4c] + InteractiveUtils
  [76f85450] + LibGit2
  [8f399da3] + Libdl
  [37e2e46d] + LinearAlgebra
  [56ddb016] + Logging
  [d6f4376e] + Markdown
  [a63ad114] + Mmap
  [44cfe95a] + Pkg
  [de0858da] + Printf
  [3fa0cd96] + REPL
  [9a3f8284] + Random
  [ea8e919c] + SHA
  [9e88b42a] + Serialization
  [1a1011a3] + SharedArrays
  [6462fe0b] + Sockets
  [2f01184e] + SparseArrays
  [10745b16] + Statistics
  [8dfed614] + Test
  [cf7118a7] + UUIDs
  [4ec0a83e] + Unicode
  Updating registry at `~/.julia/registries/General`
  Updating git-repo `https://github.com/JuliaRegistries/General.git`
 Resolving package versions...
  Updating `~/.julia/dev/PackageCompiler/packages/CSV/Project.toml`
  [9b87118b] + PackageCompiler v0.6.3
  [44cfe95a] + Pkg
  Updating `~/.julia/dev/PackageCompiler/packages/CSV/Manifest.toml`
  [c7e460c6] + ArgParse v0.6.2
  [9e28174c] + BinDeps v0.8.10
  [e1450e63] + BufferedStreams v1.0.0
  [0862f596] + HTTPClient v0.2.1
  [b27032c2] + LibCURL v0.5.0
  [522f3ed2] + LibExpat v0.5.0
  [2ec943e9] + Libz v1.0.0
  [9b87118b] + PackageCompiler v0.6.3
  [b718987f] + TextWrap v0.3.0
  [30578b45] + URIParser v0.4.0
  [c17dfb99] + WinRPM v0.4.2
[ Info: activating new environment at ~/.julia/dev/PackageCompiler/packages/CSV/Project.toml.
  Updating registry at `~/.julia/registries/General`
  Updating git-repo `https://github.com/JuliaRegistries/General.git`
CSV: Error During Test at /Users/nathan.daly/.julia/packages/CSV/tT4Xy/test/runtests.jl:19
  Got exception outside of a @test
  LoadError: ArgumentError: Package DecFP [55939f99-70c6-5e9b-8bb0-5071ed7d61fd] is required but does not seem to be installed:
   - Run `Pkg.instantiate()` to install all recorded dependencies.
```

Notice that it never adds `DecFP` to the new `Project.toml`, despite CSV.jl having it in its test REQUIRE:
https://github.com/JuliaData/CSV.jl/blob/v0.4.3/test/REQUIRE

-----------

This is fixed in this PR, and the final step includes one more output block from `Pkg.resolve()`:
```
 Resolving package versions...
  Updating `~/.julia/dev/PackageCompiler/packages/CSV/Project.toml`
  [336ed68f] + CSV v0.4.3
  [55939f99] + DecFP v0.4.8
  Updating `~/.julia/dev/PackageCompiler/packages/CSV/Manifest.toml`
  [336ed68f] + CSV v0.4.3
  [55939f99] + DecFP v0.4.8
  [276daf66] + SpecialFunctions v0.7.2
  [9abbd945] + Profile
  Updating registry at `~/.julia/registries/General`
  Updating git-repo `https://github.com/JuliaRegistries/General.git`
[ Info: activating new environment at ~/.julia/dev/PackageCompiler/packages/CSV/Project.toml.
  Updating registry at `~/.julia/registries/General`
  Updating git-repo `https://github.com/JuliaRegistries/General.git`
testing test_utf8_with_BOM.csv
...
All done
┌ Info: Not replacing system image.
└ You can start julia with `julia -J /Users/nathan.daly/.julia/dev/PackageCompiler/sysimg/sys.dylib` at a posix shell to load the compiled files.
"/Users/nathan.daly/.julia/dev/PackageCompiler/sysimg/sys.dylib"
```