### PR TITLE
Avoid serializing Base.repl_hooks and Base.package_callbacks

### DIFF
--- a/src/incremental.jl
+++ b/src/incremental.jl
@@ -47,11 +47,31 @@ function ExitHooksEnd()
     """
 end
 
+function PackageCallbacksStart()
+    """
+    package_callbacks_copy = copy(Base.package_callbacks)
+    empty!(Base.package_callbacks)
+    """
+end
+
+function PackageCallbacksEnd()
+    """
+    empty!(Base.package_callbacks)
+    append!(Base.package_callbacks, package_callbacks_copy)
+    """
+end
+
 """
 The command to pass to julia --output-o, that runs the julia code in `path` during compilation.
 """
 function PrecompileCommand(path)
-    ExitHooksStart() * InitBase() * InitREPL() * Include(path) * ExitHooksEnd()
+    ExitHooksStart() *
+        PackageCallbacksStart() *
+        InitBase() *
+        InitREPL() *
+        Include(path) *
+        PackageCallbacksEnd() *
+        ExitHooksEnd()
 end
 
 

--- a/src/incremental.jl
+++ b/src/incremental.jl
@@ -75,6 +75,24 @@ function REPLHooksEnd()
     """
 end
 
+function DisableLibraryThreadingHooksStart()
+    """
+    if isdefined(Base, :disable_library_threading_hooks)
+        disable_library_threading_hooks_copy = copy(Base.disable_library_threading_hooks)
+        empty!(Base.disable_library_threading_hooks)
+    end
+    """
+end
+
+function DisableLibraryThreadingHooksEnd()
+    """
+    if isdefined(Base, :disable_library_threading_hooks)
+        empty!(Base.disable_library_threading_hooks)
+        append!(Base.disable_library_threading_hooks, disable_library_threading_hooks_copy)
+    end
+    """
+end
+
 """
 The command to pass to julia --output-o, that runs the julia code in `path` during compilation.
 """
@@ -82,9 +100,11 @@ function PrecompileCommand(path)
     ExitHooksStart() *
         PackageCallbacksStart() *
         REPLHooksStart() *
+        DisableLibraryThreadingHooksStart() *
         InitBase() *
         InitREPL() *
         Include(path) *
+        DisableLibraryThreadingHooksEnd() *
         REPLHooksEnd() *
         PackageCallbacksEnd() *
         ExitHooksEnd()

--- a/src/incremental.jl
+++ b/src/incremental.jl
@@ -61,15 +61,31 @@ function PackageCallbacksEnd()
     """
 end
 
+function REPLHooksStart()
+    """
+    repl_hooks_copy = copy(Base.repl_hooks)
+    empty!(Base.repl_hooks)
+    """
+end
+
+function REPLHooksEnd()
+    """
+    empty!(Base.repl_hooks)
+    append!(Base.repl_hooks, repl_hooks_copy)
+    """
+end
+
 """
 The command to pass to julia --output-o, that runs the julia code in `path` during compilation.
 """
 function PrecompileCommand(path)
     ExitHooksStart() *
         PackageCallbacksStart() *
+        REPLHooksStart() *
         InitBase() *
         InitREPL() *
         Include(path) *
+        REPLHooksEnd() *
         PackageCallbacksEnd() *
         ExitHooksEnd()
 end


### PR DESCRIPTION
This does what is already done for `Base.atexit_hooks` to `Base.repl_hooks` and `Base.package_callbacks`.  Before this PR, I could have two `Requires.loadpkg` entries in `Base.package_callbacks`.  I don't know how to invoke problems related to `Base.repl_hooks` in real-world packages yet.  But it seems that we need this treatment based on observations in other hooks.
