### PR TITLE
Add verbose println for snoop w/ name of snoopfile

### DIFF
--- a/src/static_julia.jl
+++ b/src/static_julia.jl
@@ -147,6 +147,7 @@ function static_julia(
     if object
         if snoopfile != nothing
             snoopfile = abspath(snoopfile)
+            verbose && println("Executing snoopfile: \"$snoopfile\"")
             precompfile = joinpath(builddir, "precompiled.jl")
             snoop(nothing, nothing, snoopfile, precompfile)
             jlmain = joinpath(builddir, "julia_main.jl")


### PR DESCRIPTION
Sometimes the snoop file can take a while to run, and there's currently no indication it's running, so it's nice to know that it's not just hanging. :)