### PR TITLE
Use `import` instead of `using` in precompile file

### DIFF
--- a/src/snooping.jl
+++ b/src/snooping.jl
@@ -46,7 +46,7 @@ function snoop(package, tomlpath, snoopfile, outputfile, reuse = false, blacklis
     if !isempty(used_packages)
         packages = join(setdiff(used_packages,string.(blacklist)), ", ")
         usings *= """
-        using $packages
+        import $packages
         for Mod in [$packages]
             isdefined(Mod, :__init__) && Mod.__init__()
         end


### PR DESCRIPTION
`using` of a package may introduce a name same as a package to be imported later.  Importing packages with `import` is safer.