### PR TITLE
Fix for julia 1.2

### DIFF
--- a/src/snooping.jl
+++ b/src/snooping.jl
@@ -13,6 +13,8 @@ function snoop(package, tomlpath, snoopfile, outputfile, reuse = false, blacklis
         append!(Base.LOAD_PATH, $(repr(Base.LOAD_PATH)))
         Pkg.activate($(repr(tomlpath)))
         Pkg.instantiate()
+        Pkg.resolve()
+        Pkg.instantiate()
         """
     end
 


### PR DESCRIPTION
Fixes https://github.com/JuliaLang/PackageCompiler.jl/issues/242

Running in julia 1.2-rc2, the error is, e.g. `compile_incremental(:Makie)`
> ERROR: LoadError: `Documenter` is a direct dependency, but does not appear in the manifest. If you intend `Documenter` to be a direct dependency, run `Pkg.resolve()` to populate the manifest. Otherwise, remove `Documenter` with `Pkg.rm("Documenter")`. Finally, run `Pkg.instantiate()` again.


As per https://github.com/JuliaLang/Pkg.jl/issues/1106 and https://github.com/JuliaLang/Pkg.jl/pull/1209, 
> run `Pkg.resolve()` to populate the manifest. Finally, run `Pkg.instantiate()` again.

to use direct dependency and get a correct toml file.