### PR TITLE
Fix shared library compilation

### DIFF
--- a/src/static_julia.jl
+++ b/src/static_julia.jl
@@ -298,9 +298,9 @@ function build_shared(s_file, o_file, init_shared, builddir, verbose, optimize, 
     else
         o_file = `-Wl,--whole-archive $o_file -Wl,--no-whole-archive`
     end
-    command = `$cc -shared -DJULIAC_PROGRAM_LIBNAME=\"$s_file\" -o $s_file $o_file $i_file $(julia_flags(optimize, debug, cc_flags))`
+    command = `$cc -shared -DJULIAC_PROGRAM_LIBNAME=\"$(joinpath(builddir, s_file))\" -o $s_file $o_file $i_file $(julia_flags(optimize, debug, cc_flags))`
     if Sys.isapple()
-        command = `$command -Wl,-install_name,@rpath/$s_file`
+        command = `$command -Wl,-install_name,@rpath/$(joinpath(builddir, s_file))`
     elseif Sys.iswindows()
         command = `$command -Wl,--export-all-symbols`
     end

--- a/src/static_julia.jl
+++ b/src/static_julia.jl
@@ -113,7 +113,6 @@ function static_julia(
         quiet || println("C program file:\n  \"$cprog\"")
     end
 
-    builddir = abspath(builddir)
     quiet || println("Build directory:\n  \"$builddir\"")
 
     if [clean, object, shared, executable, rmtemp, copy_julialibs, copy_files] == [false, false, false, false, false, false, nothing]


### PR DESCRIPTION
Resolves #257 on osx.

```julia
# hello.jl

Base.@ccallable foo(x::Cint)::Cint = 42
Base.@ccallable bar(x::Cint)::Cint = x
Base.@ccallable function baz(x::Cint)::Cint
    println("hello world"); return 0
end
```

```bash
julia --project juliac.jl -vasij `pwd`/hello.jl
```

```python
# ipython - python 3.7.3
In [1]: import ctypes

In [2]: lib = ctypes.CDLL("./builddir/hello.dylib")

In [3]: lib.init_jl_runtime()
Out[3]: -1760573952

In [4]: lib.foo(1)
Out[4]: 42

In [5]: lib.bar(1)
Out[5]: 1

In [6]: lib.baz(0)
hello world
Out[6]: 0

In [7]:

```

<img width="1680" alt="Screen Shot 2019-07-27 at 12 24 26 PM" src="https://user-images.githubusercontent.com/1813121/61998231-49a3bc00-b06a-11e9-8a83-47ebaa8ec7c0.png">
