### PR TITLE
Fix broken Pkg API use in sd-notomls

### DIFF
--- a/src/incremental.jl
+++ b/src/incremental.jl
@@ -1,4 +1,5 @@
 """
+    InitBase()
 Init basic C libraries
 """
 function InitBase()
@@ -9,7 +10,8 @@ function InitBase()
 end
 
 """
-# Initialize REPL module for Docs
+    InitRepl()
+Initialize REPL module for Docs
 """
 function InitREPL()
     """
@@ -20,14 +22,15 @@ end
 function Include(path)
     """
     Mod = @eval module \$(gensym("anon_module")) end
-    # Include into anonymous module to not polute namespace
+    # Include into anonymous module, so as not to pollute the namespace.
     Mod.include($(repr(path)))
     """
 end
 
 """
-Exit hooks can get serialized and therefore end up in weird behaviour
-When incrementally compiling
+    ExitHooksStart()
+Exit hooks can get serialized, and therefore end up in weird behaviour
+when incrementally compiling
 """
 function ExitHooksStart()
     """
@@ -93,6 +96,7 @@ function DisableLibraryThreadingHooksEnd()
 end
 
 """
+    PrecompileCommand(path)
 The command to pass to julia --output-o, that runs the julia code in `path` during compilation.
 """
 function PrecompileCommand(path)

--- a/src/snooping.jl
+++ b/src/snooping.jl
@@ -134,6 +134,7 @@ function snoop(snoopfile::String, output_io::IO; verbose = false)
 end
 
 """
+    to_pkgid(pspec::Pkg.Types.PackageSpec)
 PackageSpec has bad hashing behavior, so we use PkgId in places
 """
 to_pkgid(pspec::Pkg.Types.PackageSpec) = Base.PkgId(pspec.uuid, pspec.name)
@@ -180,7 +181,7 @@ function snoop_packages(
     missing_pkgs = not_installed(Types.PackageSpec[direct_test_deps...])
     if install && !isempty(missing_pkgs)
         Pkg.API.add(ctx, missing_pkgs)
-    else
+    elseif isempty(missing_pkgs)
         @warn("The following test dependencies are not installed: $missing_pkgs.
         Snooping based on test scripts will likely fail.
         Please use `install = true` or install those packages manually")

--- a/src/snooping.jl
+++ b/src/snooping.jl
@@ -79,7 +79,7 @@ function snoop(snoopfile::String, output_io::IO; verbose = false)
     try
         include($(repr(snoopfile)))
     catch e
-        @warn("Snoop file errored. Precompile statements were recorded untill error!", exception = e)
+        @warn("Snoop file errored. Precompile statements were recorded until error!", exception = e)
     end
     """
     # let's use a file in the PackageCompiler dir,
@@ -179,7 +179,7 @@ function snoop_packages(
     direct_test_deps = test_dependencies(pkgs)
     missing_pkgs = not_installed(Types.PackageSpec[direct_test_deps...])
     if install && !isempty(missing_pkgs)
-        Pkg.API.add_or_develop(ctx, missing_pkgs, mode = :add)
+        Pkg.API.add(ctx, missing_pkgs)
     else
         @warn("The following test dependencies are not installed: $missing_pkgs.
         Snooping based on test scripts will likely fail.

--- a/src/snooping.jl
+++ b/src/snooping.jl
@@ -1,7 +1,7 @@
 using Pkg, Serialization
 
 
-const packages_needing_initialization = [:GR]
+const packages_needing_initialization = [:GR, :Unitful]
 
 """
     init_package!(packages::Symbol...)


### PR DESCRIPTION
Also fix a warning being thrown when unnecessary.

(Note: This is based off of, and being merged into, `sd-notomls`- not master!)