### PR TITLE
Allow to precompile Makie by fixing issue #271

### DIFF
--- a/src/snooping.jl
+++ b/src/snooping.jl
@@ -12,7 +12,7 @@ function snoop(package, tomlpath, snoopfile, outputfile, reuse = false, blacklis
         # Take LOAD_PATH from parent process
         append!(Base.LOAD_PATH, $(repr(Base.LOAD_PATH)))
         Pkg.activate($(repr(tomlpath)))
-        Pkg.instantiate()
+        Pkg.resolve()
         """
     end
 

--- a/src/snooping.jl
+++ b/src/snooping.jl
@@ -13,6 +13,7 @@ function snoop(package, tomlpath, snoopfile, outputfile, reuse = false, blacklis
         append!(Base.LOAD_PATH, $(repr(Base.LOAD_PATH)))
         Pkg.activate($(repr(tomlpath)))
         Pkg.resolve()
+        Pkg.instantiate()
         """
     end
 


### PR DESCRIPTION
The hint in https://github.com/JuliaLang/PackageCompiler.jl/issues/271#issuecomment-532443430
helped me to precompile Makie on a clean Julia 1.2 installation on openSUSE Tumbleweed.
Otherwise I had the same issue  with ParameterizedFunctions in place of FixedPointNumbers.

Jürgen
