### PR TITLE
Add hashbang to juliac.jl

### DIFF
--- a/juliac.jl
+++ b/juliac.jl
@@ -1,3 +1,5 @@
+#!/usr/bin/env julia
+
 # ArgParse can't be a dependency here,
 # so users need to install it.
 using ArgParse, PackageCompiler


### PR DESCRIPTION
Right now you need to use `julia juliac.jl <args>`.  Simply adding this hashbang should make it so one can symlink the compiler into a directory on their $PATH  `ln juliac.jl -T $some_path_dir`.  They may need to `chmod a+x juliac.jl`.  Then it can be called just as `juliac.jl -vas helloworld.jl`