### PR TITLE
Fixed ARM 32bit compile failure - see Issue

### DIFF
--- a/src/static_julia.jl
+++ b/src/static_julia.jl
@@ -319,7 +319,8 @@ function build_exec(e_file, cprog, s_file, builddir, verbose, optimize, debug, c
     else
         command = `$command -Wl,-rpath,\$ORIGIN`
     end
-    if Int == Int32
+    # line below breaking ARM arch 32bit as can be Int32 as well - so make check more specific
+    if Int == Int32  && Sys.iswindows()
         # TODO: this was added because of an error with julia on win32 that suggested this line, it seems to work but I'm not sure if it's correct
         command = `$command -march=pentium4`
     end


### PR DESCRIPTION
Fix proposed as per information provided in **Issue: #297**

**Summary:** currrently compiling on 32bit ARM architicture is broken. Cause is a 32bit check that is meant only for Windows. Making the check specific to 32 bit Window only, fixed the ARM 32bit compile failure.