### PR TITLE
Allow WinRPM 1.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,7 +12,7 @@ WinRPM = "c17dfb99-b4f7-5aad-8812-456da1ad7187"
 
 [compat]
 julia = "1"
-WinRPM = "0.4.3"
+WinRPM = "0.4.3, 1"
 
 [extras]
 ColorTypes = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"


### PR DESCRIPTION
WinRPM was updated in https://github.com/JuliaPackaging/WinRPM.jl/pull/177 so as not to depend on obsolete HTTPClient.jl, which blocked updates to Compat.jl elsewhere.  