### PR TITLE
Run Travis on Julia nightly (but allow Travis to fail on Julia nightly)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ os:
   - windows
 julia:
   - 1.3
+  - nightly
 addons:
   apt:
     sources:
@@ -23,6 +24,9 @@ arch:
 after_success:
   - julia -e 'using Pkg; Pkg.add("Coverage"); using Coverage; Codecov.submit(process_folder())'
 jobs:
+  fast_finish: true
+  allow_failures:
+    - julia: nightly
   exclude:
     - os: osx
       arch: x86


### PR DESCRIPTION
This pull request:
- Runs Travis on Julia nightly
- Allows Travis to fail on Julia nightly
- Sets `fast_finish` to `true` so that Travis can return a `success` status even if some jobs are still running, as long as all of the still-running jobs are allowed to fail