### PR TITLE
WIP: Add `download_compiler` function to optionally download compilers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,10 +14,7 @@ addons:
     sources:
       - ubuntu-toolchain-r-test
 before_install:
-  - if [ $USE_ARTIFACTS_COMPILER != "true" ] && [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo apt-get update; fi
-  - if [ $USE_ARTIFACTS_COMPILER != "true" ] && [ "$TRAVIS_OS_NAME" = "linux" ] && [ $TRAVIS_CPU_ARCH != "arm64" ]; then sudo apt-get install gcc-8 gcc-8-multilib linux-libc-dev linux-headers-generic; fi
-  - if [ $USE_ARTIFACTS_COMPILER != "true" ] && [ "$TRAVIS_OS_NAME" = "linux" ] && [ $TRAVIS_CPU_ARCH != "arm64" ]; then sudo ln -s /usr/bin/gcc-8 /usr/local/bin/gcc; fi
-  - if [ $USE_ARTIFACTS_COMPILER != "true" ] && [ "$TRAVIS_OS_NAME" = "linux" ] && [ $TRAVIS_CPU_ARCH != "arm64" ]; then sudo ln -s /usr/include/asm-generic /usr/include/asm; fi
+  - if [ $USE_ARTIFACTS_COMPILER != "true" ] && [ "$TRAVIS_OS_NAME" = "linux" ] && [ $TRAVIS_CPU_ARCH != "arm64" ]; then sudo apt-get update && sudo apt-get install gcc-8 gcc-8-multilib linux-libc-dev linux-headers-generic && ln -s /usr/bin/gcc-8 /usr/local/bin/gcc && /usr/include/asm-generic /usr/include/asm; fi
   - which gcc
   - gcc --version
 arch:
@@ -37,6 +34,10 @@ jobs:
       arch: arm64
     - os: windows
       arch: arm64
+    - arch: arm64
+      USE_ARTIFACTS_COMPILER: true
+    - arch: x86
+      USE_ARTIFACTS_COMPILER: true
   include:
     - stage: "Documentation"
       julia: 1.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ os:
 julia:
   - 1.3
   - nightly
+env:
+  - USE_ARTIFACTS_COMPILER=true
+  - USE_ARTIFACTS_COMPILER=false
 addons:
   apt:
     sources:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,10 +14,10 @@ addons:
     sources:
       - ubuntu-toolchain-r-test
 before_install:
-  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo apt-get update; fi
-  - if [ "$TRAVIS_OS_NAME" = "linux" ] && [ $TRAVIS_CPU_ARCH != "arm64" ]; then sudo apt-get install gcc-8 gcc-8-multilib linux-libc-dev linux-headers-generic; fi
-  - if [ "$TRAVIS_OS_NAME" = "linux" ] && [ $TRAVIS_CPU_ARCH != "arm64" ]; then sudo ln -s /usr/bin/gcc-8 /usr/local/bin/gcc; fi
-  - if [ "$TRAVIS_OS_NAME" = "linux" ] && [ $TRAVIS_CPU_ARCH != "arm64" ]; then sudo ln -s /usr/include/asm-generic /usr/include/asm; fi
+  - if [ $USE_ARTIFACTS_COMPILER != "true" ] && [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo apt-get update; fi
+  - if [ $USE_ARTIFACTS_COMPILER != "true" ] && [ "$TRAVIS_OS_NAME" = "linux" ] && [ $TRAVIS_CPU_ARCH != "arm64" ]; then sudo apt-get install gcc-8 gcc-8-multilib linux-libc-dev linux-headers-generic; fi
+  - if [ $USE_ARTIFACTS_COMPILER != "true" ] && [ "$TRAVIS_OS_NAME" = "linux" ] && [ $TRAVIS_CPU_ARCH != "arm64" ]; then sudo ln -s /usr/bin/gcc-8 /usr/local/bin/gcc; fi
+  - if [ $USE_ARTIFACTS_COMPILER != "true" ] && [ "$TRAVIS_OS_NAME" = "linux" ] && [ $TRAVIS_CPU_ARCH != "arm64" ]; then sudo ln -s /usr/include/asm-generic /usr/include/asm; fi
   - which gcc
   - gcc --version
 arch:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ julia:
   - 1.3
   - nightly
 env:
-  - USE_ARTIFACTS_COMPILER=true
-  - USE_ARTIFACTS_COMPILER=false
+  - JULIA_DEBUG=all USE_ARTIFACTS_COMPILER=true
+  - JULIA_DEBUG=all USE_ARTIFACTS_COMPILER=false
 addons:
   apt:
     sources:

--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -20,7 +20,7 @@ lazy = true
 
 [[clang]]
 git-tree-sha1 = "f6797ce93d656e60eb39db5c53438eb5402415f8"
-os = "macos"
+os = "linux"
 arch = "x86_64"
 lazy = true
 

--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -7,3 +7,23 @@ lazy = true
     [[x86_64-w64-mingw32.download]]
     sha256 = "fe3f401bc936fbe6af940b26c5e0f266f762a3416f979c706e599b24082dc5c7"
     url = "https://github.com/JuliaComputing/PackageCompilerX.jl/releases/download/v0.1/x86_64-8.1.0-release-posix-seh-rt_v6-rev0.tar.gz"
+
+[[clang]]
+git-tree-sha1 = "36ecb2ff7a75d3bcfd844cdcddbda601854f60f9"
+os = "macos"
+arch = "x86_64"
+lazy = true
+
+    [[clang.download]]
+    sha256 = "b46e3fe3829d4eb30ad72993bf28c76b1e1f7e38509fbd44192a2ef7c0126fc7"
+    url = "https://releases.llvm.org/9.0.0/clang+llvm-9.0.0-x86_64-darwin-apple.tar.xz"
+
+[[clang]]
+git-tree-sha1 = "f6797ce93d656e60eb39db5c53438eb5402415f8"
+os = "macos"
+arch = "x86_64"
+lazy = true
+
+    [[clang.download]]
+    sha256 = "616c5f75418c88a72613b6d0a93178028f81357777226869ea6b34c23d08a12d"
+    url = "https://releases.llvm.org/9.0.0/clang+llvm-9.0.0-x86_64-pc-linux-gnu.tar.xz"

--- a/src/PackageCompiler.jl
+++ b/src/PackageCompiler.jl
@@ -5,7 +5,11 @@ using Libdl: Libdl
 using Pkg: Pkg
 using UUIDs: UUID
 
-export create_sysimage, create_app, audit_app, restore_default_sysimage
+export audit_app,
+       create_app,
+       create_sysimage,
+       download_compiler,
+       restore_default_sysimage
 
 include("juliaconfig.jl")
 
@@ -75,6 +79,27 @@ function windows_compiler_artifact_path(f, compiler)
     else
         f()
     end
+end
+
+function _get_artifacts_compiler()
+    if Sys.iswindows()
+        return joinpath(Pkg.Artifacts.artifact"x86_64-w64-mingw32", "mingw64", "bin", "gcc.exe")
+    else
+        clang_root = Pkg.Artifacts.artifact"clang"
+        return joinpath(clang_root, first(readdir(clang_root)), "bin", "clang")
+    end
+end
+
+"""
+    download_compiler()
+
+Download a C compiler and set `ENV["JULIA_CC"]` to the path of the downloaded
+compiler.
+"""
+function download_compiler()
+    artifacts_compiler = _get_artifacts_compiler()
+    ENV["JULIA_CC"] = artifacts_compiler
+    return artifacts_compiler
 end
 
 function get_compiler()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -17,7 +17,22 @@ if haskey(ENV, "CI")
     @show Sys.ARCH
 end
 
+function use_artifacts_compiler_in_tests()
+    if lowercase(strip(get(ENV, "USE_ARTIFACTS_COMPILER", ""))) == "true"
+        if Sys.ARCH == :x86_64 && ( Sys.iswindows() || Sys.isapple() || Sys.islinux() )
+            return true
+        else
+            return false
+        end
+    else
+        return false
+    end
+end
+
 @testset "PackageCompiler.jl" begin
+    if use_artifacts_compiler_in_tests()
+        PackageCompiler.download_compiler()
+    end
     tmp = mktempdir()
     sysimage_path = joinpath(tmp, "sys." * Libdl.dlext)
     script = tempname()


### PR DESCRIPTION
This pull request adds the function `PackageCompiler.download_compiler`.

Running `PackageCompiler.download_compiler()` on 64-bit Linux or macOS will download Clang and set `ENV["JULIA_CC"]` to the path of the downloaded compiler.