### PR TITLE
[documentation] Some very minor improvements to the docstring of `create_app`

### DIFF
--- a/src/PackageCompiler.jl
+++ b/src/PackageCompiler.jl
@@ -512,7 +512,7 @@ function audit_app(ctx::Pkg.Types.Context)
 end
 
 """
-    create_app(app_source::String, compiled_app::String)
+    create_app(app_source::String, compiled_app::String; kwargs...)
 
 Compile an app with the source in `app_source` to the folder `compiled_app`.
 The folder `app_source` needs to contain a package where the package include a
@@ -551,6 +551,8 @@ compiler.
    to `true`.
 
 - `force::Bool`: Remove the folder `compiled_app` if it exists before creating the app.
+
+### Advanced keyword arguments
 
 - `cpu_target::String`: The value to use for `JULIA_CPU_TARGET` when building the system image.
 """


### PR DESCRIPTION
This PR makes a few small tweaks to the docstring of `create_app`:
1. Make sure that `kwargs...` is part of the signature.
2. Put the `cpu_target` keyword argument into a section at the bottom labelled `Advanced keyword arguments`.

These two changes make the docstring of `create_app` more consistent with the docstring of `create_sysimage`.