### PR TITLE
Suggestion to add `precompile_statements_file_out` option

### DIFF
--- a/src/PackageCompiler.jl
+++ b/src/PackageCompiler.jl
@@ -276,13 +276,11 @@ function create_sysimg_object_file(object_file::String, packages::Vector{String}
     try
         run(cmd)
     catch e
-        bt = catch_backtrace()
         if length(tracefiles) > 0
-            @error "Julia experienced an error while compiling the sysimage. The precompile statements generated during execution of $precompile_execution_file have been saved to $tracefiles"
+            error("An error occurred while compiling the sysimage. The precompile statements generated during execution of $precompile_execution_file have been saved to $tracefiles")
         else
-            @error "Julia experienced an error while compiling the sysimage"
+            error("An error occurred while compiling the sysimage")
         end
-        showerror(stderr, e, bt)
     end
 end
 

--- a/src/PackageCompiler.jl
+++ b/src/PackageCompiler.jl
@@ -192,14 +192,6 @@ function create_sysimg_object_file(object_file::String, packages::Vector{String}
         precompile_statements *=
             "    append!(precompile_statements, readlines($(repr(file))))\n"
     end
-    
-    if precompile_statements_file_out != ""
-        open(precompile_statements_file_out, "w") do f
-            for statement in eval(Meta.parse(precompile_statements))
-                println(f, statement)
-            end
-        end
-    end
 
     precompile_code = """
         # This @eval prevents symbols from being put into Main
@@ -212,6 +204,15 @@ function create_sysimg_object_file(object_file::String, packages::Vector{String}
             end
             precompile_statements = String[]
             $precompile_statements
+
+            if "$precompile_statements_file_out" != ""
+                open("$precompile_statements_file_out", "w") do f
+                    for statement in precompile_statements
+                        println(f, statement)
+                    end
+                end
+            end
+
             for statement in sort(precompile_statements)
                 # println(statement)
                 try

--- a/src/PackageCompiler.jl
+++ b/src/PackageCompiler.jl
@@ -175,6 +175,7 @@ function create_sysimg_object_file(object_file::String, packages::Vector{String}
                             base_sysimage::String,
                             precompile_execution_file::Vector{String},
                             precompile_statements_file::Vector{String},
+                            precompile_statements_file_out::String,
                             cpu_target::String,
                             script::Union{Nothing, String},
                             isapp::Bool)
@@ -190,6 +191,14 @@ function create_sysimg_object_file(object_file::String, packages::Vector{String}
     for file in precompile_statements_file
         precompile_statements *=
             "    append!(precompile_statements, readlines($(repr(file))))\n"
+    end
+    
+    if precompile_statements_file_out != ""
+        open(precompile_statements_file_out, "w") do f
+            for statement in eval(Meta.parse(precompile_statements))
+                println(f, statement)
+            end
+        end
     end
 
     precompile_code = """
@@ -327,6 +336,9 @@ by setting the environment variable `JULIA_CC` to a path to a compiler
 - `precompile_statements_file::Union{String, Vector{String}}`: A file or list of
    files that contains precompilation statements that should be included in the sysimage.
 
+- `precompile_statements_file_out::String`: A file where the total list of precompilation
+   statements will be saved. Skipped by default.
+
 - `incremental::Bool`: If `true`, build the new sysimage on top of the sysimage
    of the current process otherwise build a new sysimage from scratch. Defaults to `true`.
 
@@ -347,6 +359,7 @@ function create_sysimage(packages::Union{Symbol, Vector{Symbol}}=Symbol[];
                          project::String=dirname(active_project()),
                          precompile_execution_file::Union{String, Vector{String}}=String[],
                          precompile_statements_file::Union{String, Vector{String}}=String[],
+                         precompile_statements_file_out::String="",
                          incremental::Bool=true,
                          filter_stdlibs=false,
                          replace_default::Bool=false,
@@ -407,6 +420,7 @@ function create_sysimage(packages::Union{Symbol, Vector{Symbol}}=Symbol[];
                               base_sysimage=base_sysimage,
                               precompile_execution_file=precompile_execution_file,
                               precompile_statements_file=precompile_statements_file,
+                              precompile_statements_file_out=precompile_statements_file_out,
                               cpu_target=cpu_target,
                               script=script,
                               isapp=isapp)
@@ -541,6 +555,9 @@ compiler.
    files that contains precompilation statements that should be included in the sysimage
    for the app.
 
+- `precompile_statements_file_out::String`: A file where the total list of precompilation
+   statements will be saved. Skipped by default.
+
 - `incremental::Bool`: If `true`, build the new sysimage on top of the sysimage
    of the current process otherwise build a new sysimage from scratch. Defaults to `false`.
 
@@ -560,6 +577,7 @@ function create_app(package_dir::String,
                     app_dir::String;
                     precompile_execution_file::Union{String, Vector{String}}=String[],
                     precompile_statements_file::Union{String, Vector{String}}=String[],
+                    precompile_statements_file_out::String="",
                     incremental=false,
                     filter_stdlibs=false,
                     audit=true,
@@ -609,6 +627,7 @@ function create_app(package_dir::String,
                             incremental=true,
                             precompile_execution_file=precompile_execution_file,
                             precompile_statements_file=precompile_statements_file,
+                            precompile_statements_file_out=precompile_statements_file_out,
                             cpu_target=cpu_target,
                             base_sysimage=tmp_base_sysimage,
                             isapp=true)
@@ -617,6 +636,7 @@ function create_app(package_dir::String,
                                               incremental=incremental, filter_stdlibs=filter_stdlibs,
                                               precompile_execution_file=precompile_execution_file,
                                               precompile_statements_file=precompile_statements_file,
+                                              precompile_statements_file_out=precompile_statements_file_out,
                                               cpu_target=cpu_target,
                                               isapp=true)
         end

--- a/src/PackageCompiler.jl
+++ b/src/PackageCompiler.jl
@@ -204,7 +204,6 @@ function create_sysimg_object_file(object_file::String, packages::Vector{String}
             end
             precompile_statements = String[]
             $precompile_statements
-
             for statement in sort(precompile_statements)
                 # println(statement)
                 try
@@ -278,7 +277,11 @@ function create_sysimg_object_file(object_file::String, packages::Vector{String}
         run(cmd)
     catch e
         bt = catch_backtrace()
-        @error "Julia experienced an error while compiling the sysimage. The precompile statements generated during execution of $precompile_execution_file have been saved to $tracefiles"
+        if length(tracefiles) > 0
+            @error "Julia experienced an error while compiling the sysimage. The precompile statements generated during execution of $precompile_execution_file have been saved to $tracefiles"
+        else
+            @error "Julia experienced an error while compiling the sysimage"
+        end
         showerror(stderr, e, bt)
     end
 end


### PR DESCRIPTION
For debugging purposes. Just saves the total list to file.
Not sure if helpful in the broader sense. Just a suggestion.