### PR TITLE
Require that Travis passes on nightly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ after_success:
 jobs:
   fast_finish: true
   allow_failures:
-    - julia: nightly
+    # - julia: nightly
   exclude:
     - os: osx
       arch: x86


### PR DESCRIPTION
Now that tests are passing on master, let’s require that Travis passes on master. That way, we’ll notice if tests start failing again on master.