### PR TITLE
fix typo error in code to create sysimage

### DIFF
--- a/docs/src/devdocs/sysimages_part_1.md
+++ b/docs/src/devdocs/sysimages_part_1.md
@@ -438,7 +438,7 @@ using CSV
 @eval Module() begin
     for (pkgid, mod) in Base.loaded_modules
         if !(pkgid.name in ("Main", "Core", "Base"))
-            eval(@__MODULE__, :(const $(Symbol(mod)) = $_mod))
+            eval(@__MODULE__, :(const $(Symbol(mod)) = $mod))
         end
     end
     for statement in readlines("csv_precompile.jl")


### PR DESCRIPTION
Typo error : `$_mod` should be `$mod`
`eval(@__MODULE__, :(const $(Symbol(mod)) = $mod))`

```Julia
Base.init_depot_path()
Base.init_load_path()

using CSV

@eval Module() begin
    for (pkgid, mod) in Base.loaded_modules
        if !(pkgid.name in ("Main", "Core", "Base"))
            eval(@__MODULE__, :(const $(Symbol(mod)) = $mod))
        end
    end
    for statement in readlines("csv_precompile.jl")
        try
            Base.include_string(@__MODULE__, statement)
        catch
            # See julia issue #28808
            @info "failed to compile statement: $statement"
        end
    end
end # module

empty!(LOAD_PATH)
empty!(DEPOT_PATH)
```