### PR TITLE
Change read to run in precompilation

### DIFF
--- a/src/PackageCompiler.jl
+++ b/src/PackageCompiler.jl
@@ -167,7 +167,7 @@ function run_precompilation_script(project::String, sysimg::String, precompile_f
     cmd = `$(get_julia_cmd()) --sysimage=$(sysimg) --project=$project
             --compile=all --trace-compile=$tracefile $arg`
     @debug "run_precompilation_script: running $cmd"
-    read(cmd)
+    run(cmd)
     return tracefile
 end
 


### PR DESCRIPTION
Ref: https://github.com/JuliaLang/PackageCompiler.jl/issues/292#issuecomment-591313331 

This change makes it so that function calls in a precompile script that involve printing will get properly compiled to print to TTY instead of STDOUT if you're compiling an app. 

This has the side-effect that all the statements in the precompile file that do print will get printed when you run `create_app`.