### PR TITLE
document base_sysimage parameter to create_sysimage

### DIFF
--- a/src/PackageCompiler.jl
+++ b/src/PackageCompiler.jl
@@ -355,6 +355,10 @@ by setting the environment variable `JULIA_CC` to a path to a compiler
 
 ### Advanced keyword arguments
 
+- `base_sysimage::Union{Nothing, String}`: If a `String`, names an existing sysimage upon which to build
+   the new sysimage incrementally, instead of the sysimage of the current process. Defaults to `nothing`.
+   Keyword argument `incremental` must be `true` if `base_sysimage` is not `nothing`.
+
 - `cpu_target::String`: The value to use for `JULIA_CPU_TARGET` when building the system image.
 
 - `script::String`: Path to a file that gets executed in the `--output-o` process.


### PR DESCRIPTION
I'd like to have the `base_sysimage` parameter to `create_sysimage` documented as part of the API.

JuliaPy/pyjulia#380 proposes using `base_sysimage` to allow pyjulia to build its custom sysimage on top of an existing custom sysimage (e.g. produced using PackageCompiler). As long as `base_sysimage` isn't documented in the PackageCompiler API it isn't safe to rely on.

The only change proposed by the PR is to the `create_sysimage` doc string to document `base_sysimage`.