### PR TITLE
Allow passing a custom c program to `create_app()`

### DIFF
--- a/src/PackageCompiler.jl
+++ b/src/PackageCompiler.jl
@@ -583,7 +583,7 @@ function create_app(package_dir::String,
                     filter_stdlibs=false,
                     audit=true,
                     force=false,
-                    c_driver_program::String="embedding_wrapper.c",
+                    c_driver_program::String=joinpath(@__DIR__, "embedding_wrapper.c"),
                     cpu_target::String=default_app_cpu_target())
     precompile_statements_file = abspath.(precompile_statements_file)
     precompile_execution_file = abspath.(precompile_execution_file)
@@ -607,6 +607,7 @@ function create_app(package_dir::String,
         end
         rm(app_dir; force=true, recursive=true)
     end
+    c_driver_program = abspath(c_driver_program)
 
     audit && audit_app(ctx)
 
@@ -660,7 +661,7 @@ function create_executable_from_sysimg(;sysimage_path::String,
                                         c_driver_program_path::String,)
     flags = join((cflags(), ldflags(), ldlibs()), " ")
     flags = Base.shell_split(flags)
-    wrapper = joinpath(@__DIR__, c_driver_program_path)
+    wrapper = c_driver_program_path
     if Sys.iswindows()
         rpath = ``
     elseif Sys.isapple()

--- a/src/PackageCompiler.jl
+++ b/src/PackageCompiler.jl
@@ -583,6 +583,7 @@ function create_app(package_dir::String,
                     filter_stdlibs=false,
                     audit=true,
                     force=false,
+                    c_driver_program::String="embedding_wrapper.c",
                     cpu_target::String=default_app_cpu_target())
     precompile_statements_file = abspath.(precompile_statements_file)
     precompile_execution_file = abspath.(precompile_execution_file)
@@ -643,7 +644,8 @@ function create_app(package_dir::String,
                                               cpu_target=cpu_target,
                                               isapp=true)
         end
-        create_executable_from_sysimg(; sysimage_path=sysimg_file, executable_path=app_name)
+        create_executable_from_sysimg(; sysimage_path=sysimg_file, executable_path=app_name,
+                                    c_driver_program_path=c_driver_program,)
         if Sys.isapple()
             cmd = `install_name_tool -change $sysimg_file @rpath/$sysimg_file $app_name`
             @debug "running $cmd"
@@ -654,10 +656,11 @@ function create_app(package_dir::String,
 end
 
 function create_executable_from_sysimg(;sysimage_path::String,
-                                        executable_path::String)
+                                        executable_path::String,
+                                        c_driver_program_path::String,)
     flags = join((cflags(), ldflags(), ldlibs()), " ")
     flags = Base.shell_split(flags)
-    wrapper = joinpath(@__DIR__, "embedding_wrapper.c")
+    wrapper = joinpath(@__DIR__, c_driver_program_path)
     if Sys.iswindows()
         rpath = ``
     elseif Sys.isapple()

--- a/src/embedding_wrapper.c
+++ b/src/embedding_wrapper.c
@@ -38,7 +38,7 @@ int main(int argc, char *argv[])
     if (uv_exepath(free_path, &path_size)) {
        jl_error("fatal error: unexpected error while retrieving exepath");
     }
- 
+
     char buf[PATH_MAX];
     snprintf(buf, sizeof(buf), "JULIA_DEPOT_PATH=%s/", dirname(dirname(free_path)));
     putenv(buf);


### PR DESCRIPTION
This will support users who need to set arbitrary julia jl_options for
julia_init. For example, configuring the binary to always run with `-O1`
or `--compile=min`.

It will of course then also support any other arbitrary changes to the C
program a user may want to make.

This is a partial fix for https://github.com/JuliaLang/PackageCompiler.jl/issues/413; it will allow us to write code to control the intializiation arguments ourselves. But as a follow-up, it might be nice to have a more complete fix where we add an option (maybe by select an alternate provided C program?) that will automatically parse command line args in the same was as the standard julia binary does.