### PR TITLE
Use older hash

### DIFF
--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -1,5 +1,5 @@
 [[x86_64-w64-mingw32]]
-git-tree-sha1 = "b910b96db4f5b375989b59407892e2723425dc8a"
+git-tree-sha1 = "fdff308295487f361ef6e8dc2d27f5abe8a6eee9"
 os = "windows"
 arch = "x86_64"
 lazy = true


### PR DESCRIPTION
Older Julias use a flawed hashing algorithm; for now we need to continue
to use it.  The Pkg and Storage servers will work around it properly.

Embarassingly, that's what I originally had, but I got confused due to thinking about things from a new Julia perspective: [`71be147` (#395)](https://github.com/JuliaLang/PackageCompiler.jl/pull/395/commits/71be147478a868305a0ceb1a2bf210e6eec0d435)