### PR TITLE
Use `import` to precompile packages (instead of using `using`)

### DIFF
--- a/src/PackageCompiler.jl
+++ b/src/PackageCompiler.jl
@@ -180,7 +180,7 @@ end
 
 # Load packages in a normal julia process to make them precompile "normally"
 function do_ensurecompiled(project, packages, sysimage)
-    use = join("using " .* packages, '\n')
+    use = join("import " .* packages, '\n')
     cmd = `$(get_julia_cmd()) --sysimage=$sysimage --project=$project -e $use`
     @debug "running $cmd"
     read(cmd, String)
@@ -248,7 +248,7 @@ function create_sysimg_object_file(object_file::String, packages::Vector{String}
 
     for pkg in packages
         julia_code *= """
-            using $pkg
+            import $pkg
             """
     end
 


### PR DESCRIPTION
Both `import Foo` and `using Foo` will result in the precompilation of `Foo`.

`using`.:
- Pros: none
- Cons: awkward name clashes if one package exports a name that clashes with the name of another package (see e.g, `Future` and `Distributed.Future`)

`import`:
- Pros: no name clashes
- Cons: none