### PR TITLE
Ensure `@artifact` is skipped on non-windows platforms

### DIFF
--- a/src/PackageCompiler.jl
+++ b/src/PackageCompiler.jl
@@ -99,7 +99,7 @@ function get_compiler()
     if cc !== nothing
         return cc
     end
-    if Sys.iswindows()
+    @static if Sys.iswindows()
         return joinpath(Pkg.Artifacts.artifact"x86_64-w64-mingw32", "mingw64", "bin", "gcc.exe")
     end
     if Sys.which("gcc") !== nothing


### PR DESCRIPTION
Because newer `@artifact` macros do more work at compile-time, we need to use a compile-time `if` statement here to avoid running the macro at all on non-windows systems.

Fixes #442