### PR TITLE
feat: add precompile_function_file option

### DIFF
--- a/src/PackageCompiler.jl
+++ b/src/PackageCompiler.jl
@@ -199,7 +199,6 @@ function create_sysimg_object_file(object_file::String, packages::Vector{String}
     # Handle precompilation
     precompile_statements = ""
     @debug "running precompilation execution script..."
-    tracefiles = String[]
     for file in (isempty(precompile_execution_file) ? (nothing,) : precompile_execution_file)
         tracefile = run_precompilation_script(project, base_sysimage, file)
         precompile_statements *= "    append!(precompile_statements, readlines($(repr(tracefile))))\n"

--- a/test/precompile_function_file.jl
+++ b/test/precompile_function_file.jl
@@ -1,0 +1,3 @@
+function _precompile_()
+    precompile(Tuple{typeof(Base.peek), Base.IOStream})
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -36,6 +36,7 @@ end
                               precompile_execution_file=joinpath(@__DIR__, "precompile_execution.jl"),
                               precompile_statements_file=joinpath.(@__DIR__, ["precompile_statements.jl",
                                                                               "precompile_statements2.jl"]),
+                              precompile_function_file=joinpath(@__DIR__, "precompile_function_file.jl"),
                               script=script)
     # Check we can load sysimage and that Example is available in Main
     str = read(`$(Base.julia_cmd()) -J $(sysimage_path) -e 'println(Example.hello("foo")); script_func()'`, String)


### PR DESCRIPTION
This adds `precompile_function_file::Union{String, Vector{String}}` option which is A file or list of files that contains a `_precompile_()` function in which it calls the precompilation statements that should be included in the sysimage for the app.

This allows more control over the precompile statements that are written in separate lines in the precompile statement files.

This is also intended to be used inside [CompileBot](https://github.com/aminya/CompileBot.jl).