### PR TITLE
Fix insufficient escaping

### DIFF
--- a/docs/src/devdocs/sysimages_part_1.md
+++ b/docs/src/devdocs/sysimages_part_1.md
@@ -424,7 +424,7 @@ statements](https://github.com/JuliaLang/julia/issues/28808) running a
 precompile statement can fail.  The solution to these issues is to load all
 modules in the sysimage by looping through `Base.loaded_modules` and to use a
 `try-catch` for each precompile statement.  In addition, we evaluate everything
-in an anonymous module to not pollute the `Main` module which a bunch of
+in an anonymous module to not pollute the `Main` module with a bunch of
 symbols.
 
 The end result is a `custom_sysimage.jl` file looking like:

--- a/src/PackageCompiler.jl
+++ b/src/PackageCompiler.jl
@@ -224,7 +224,7 @@ function create_sysimg_object_file(object_file::String, packages::Vector{String}
                 # println(statement)
                 # The compiler has problem caching signatures with `Vararg{?, N}`. Replacing
                 # N with a large number seems to work around it.
-                statement = replace(statement, r"Vararg{(.*?), N} where N" => s"Vararg{\1, 100}")
+                statement = replace(statement, r"Vararg{(.*?), N} where N" => s"Vararg{\\1, 100}")
                 try
                     Base.include_string(PrecompileStagingArea, statement)
                 catch


### PR DESCRIPTION
Add another backslash for sufficient escaping. The single backslash is fine in a regex but the regex is embedded within a regular string.
