### PR TITLE
 create_app: load "deps" packages besides just the app package

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ version = "1.2.2"
 
 [deps]
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 

--- a/src/PackageCompiler.jl
+++ b/src/PackageCompiler.jl
@@ -648,7 +648,7 @@ function create_app(package_dir::String,
     # we can load _all_ of the packages (and their recursive packages) from the project.
     # This may be more than the user will actually need, but that is up to users to prune
     # their Project files to only those `deps` actually in use.
-    packages = keys(ctx.env.project.deps )
+    packages = Symbol.(keys(ctx.env.project.deps))
 
     # TODO: Create in a temp dir and then move it into place?
     binpath = joinpath(app_dir, "bin")

--- a/src/PackageCompiler.jl
+++ b/src/PackageCompiler.jl
@@ -203,6 +203,7 @@ function create_sysimg_object_file(object_file::String, packages::Vector{String}
     tracefiles = String[]
     for file in (isempty(precompile_execution_file) ? (nothing,) : precompile_execution_file)
         tracefile = run_precompilation_script(project, base_sysimage, file)
+        @debug "precompile statements written to: $tracefile"
         precompile_statements *= "    append!(precompile_statements, readlines($(repr(tracefile))))\n"
     end
     for file in precompile_statements_file

--- a/src/PackageCompiler.jl
+++ b/src/PackageCompiler.jl
@@ -289,7 +289,6 @@ function create_sysimg_object_file(object_file::String, packages::Vector{String}
 
     if isapp
         # If it is an app, there is only one packages
-        #@assert length(packages) == 1
         packages[1]
         app_start_code = """
         Base.@ccallable function julia_main()::Cint
@@ -649,7 +648,7 @@ function create_app(package_dir::String,
     # we can load _all_ of the packages (and their recursive packages) from the project.
     # This may be more than the user will actually need, but that is up to users to prune
     # their Project files to only those `deps` actually in use.
-    packages = Symbol.(keys(Pkg.TOML.parsefile(ctx.env.project_file)["deps"]))
+    packages = keys(ctx.env.project.deps )
 
     # TODO: Create in a temp dir and then move it into place?
     binpath = joinpath(app_dir, "bin")


### PR DESCRIPTION
I now understand the cause of `Case 5` in https://github.com/JuliaLang/julia/issues/28808#issuecomment-712472418, and this PR is a first attempt at addressing it.

Before this commit, `create_app()` would only load the package for the
App being compiled before executing all precompile statements. This
means that if your precompile script was importing any "extra" packages,
that aren't used directly by the app's module, that they would silently
fail to statically compile.

We are doing this in our static compilation job to also precompile some "helper" packages that we ship alongside our application code, such as `Plots`.


I'm not sure what the best way to approach this fix is. Some options I see:
- Add a parameter to `create_app` to allow optionally specifying extra packages to include in the static compilation
- Automatically also include _all packages_ from the app's Project.toml (that's the approach I took in this PR, so far, but happy to change it)
- Add a mechanism to the execution of the snoop precompilation scripts to report out the `Base.loaded_modules` at the end of the execution, and add those to the packages.
    - I like this option the best, because things Just Work how the user would expect them to: "If I add this to my snoop file, it will get statically compiled," but I think it's slightly complicated. Probably not too hard though! :)


I would love your feedback! Thanks @KristofferC!