### PR TITLE
fix name to julia-internal-debug

### DIFF
--- a/src/juliaconfig.jl
+++ b/src/juliaconfig.jl
@@ -42,7 +42,7 @@ end
 function ldlibs(relative_path=nothing)
     libnames = if VERSION >= v"1.6.0-DEV.1673"
         if ccall(:jl_is_debugbuild, Cint, ()) != 0
-            "-ljulia-debug -ljulia-debug-internal"
+            "-ljulia-debug -ljulia-internal-debug"
         else
             "-ljulia -ljulia-internal"
         end


### PR DESCRIPTION
This is the correct ordering, see e.g.
https://github.com/JuliaLang/julia/blob/549a73b99de47700ffe7b92beec9f84789682d38/sysimage.mk#L18