### PR TITLE
Allow the precompile script to write to stdout.

### DIFF
--- a/src/PackageCompiler.jl
+++ b/src/PackageCompiler.jl
@@ -183,7 +183,7 @@ function run_precompilation_script(project::String, sysimg::String, precompile_f
     cmd = `$(get_julia_cmd()) --sysimage=$(sysimg) --project=$project
             --compile=all --trace-compile=$tracefile $arg`
     @debug "run_precompilation_script: running $cmd"
-    read(cmd)
+    run(cmd)  # `Run` this command so that we'll display stdout from the user's script.
     return tracefile
 end
 

--- a/src/PackageCompiler.jl
+++ b/src/PackageCompiler.jl
@@ -183,9 +183,9 @@ function run_precompilation_script(project::String, sysimg::String, precompile_f
     cmd = `$(get_julia_cmd()) --sysimage=$(sysimg) --project=$project
             --compile=all --trace-compile=$tracefile $arg`
     @debug "run_precompilation_script: running $cmd"
-    @info "===== Start precompile execution ====="
+    @info "\n===== Start precompile execution =====\n"
     run(cmd)  # `Run` this command so that we'll display stdout from the user's script.
-    @info "===== End precompile execution ====="
+    @info "\n===== End precompile execution =====\n"
     return tracefile
 end
 

--- a/src/PackageCompiler.jl
+++ b/src/PackageCompiler.jl
@@ -183,7 +183,9 @@ function run_precompilation_script(project::String, sysimg::String, precompile_f
     cmd = `$(get_julia_cmd()) --sysimage=$(sysimg) --project=$project
             --compile=all --trace-compile=$tracefile $arg`
     @debug "run_precompilation_script: running $cmd"
+    @info "===== Start precompile execution ====="
     run(cmd)  # `Run` this command so that we'll display stdout from the user's script.
+    @info "===== End precompile execution ====="
     return tracefile
 end
 


### PR DESCRIPTION
Since print statements in a user's precompile script are controlled by them, it's useful to allow the user to decide whether or not they want to emit stdout output when running their precompile script.

This kind of output can be useful for diagnosing why the build failed and for printing status messages during execution, etc etc.

In our case, we print extra debugging information to stdout when an error is thrown, and that was being lost when running the script in PackageCompiler, which means that if a PR breaks some functionality and it happens to be caught in our precompile_script, we lose context on what the error was.

-------

This PR proposes a change to call `run(cmd)` instead of `read(cmd)` specifically to avoid capturing and silencing the STDOUT.

I see however that it was explicitly changed from `run` to `read` in this commit:
https://github.com/JuliaLang/PackageCompiler.jl/commit/8f7d453d2e10fb6c5680d9599bac581f93252c45#diff-054fccbf7c4285c9bdfa21be5b707029e19dc178713d1d2d30b42f8bf0e4ecceR98

Is there another reason that I'm missing why `read()` is preferred here? or is the goal indeed to silence the output, and if so, what would you think about changing back to printing the output? It would be quite useful for us, and i imagine others, to be able to print from within our precompilation script.

Thanks @KristofferC! :) Happy new year!! <3