### PR TITLE
Add include_lazy_artifacts flag to create_app.

### DIFF
--- a/src/PackageCompiler.jl
+++ b/src/PackageCompiler.jl
@@ -618,7 +618,8 @@ function create_app(package_dir::String,
                     audit=true,
                     force=false,
                     c_driver_program::String=joinpath(@__DIR__, "embedding_wrapper.c"),
-                    cpu_target::String=default_app_cpu_target())
+                    cpu_target::String=default_app_cpu_target(),
+                    include_lazy_artifacts=true)
     precompile_statements_file = abspath.(precompile_statements_file)
     precompile_execution_file = abspath.(precompile_execution_file)
     package_dir = abspath(package_dir)
@@ -653,7 +654,7 @@ function create_app(package_dir::String,
     mkpath(app_dir)
 
     bundle_julia_libraries(app_dir)
-    bundle_artifacts(ctx, app_dir)
+    bundle_artifacts(ctx, app_dir; include_lazy_artifacts=include_lazy_artifacts)
 
     # TODO: Create in a temp dir and then move it into place?
     binpath = joinpath(app_dir, "bin")
@@ -741,7 +742,7 @@ function bundle_julia_libraries(app_dir)
     return
 end
 
-function bundle_artifacts(ctx, app_dir)
+function bundle_artifacts(ctx, app_dir; include_lazy_artifacts=true)
     @debug "bundling artifacts..."
 
     pkgs = load_all_deps(ctx)
@@ -764,6 +765,12 @@ function bundle_artifacts(ctx, app_dir)
                 @debug "bundling artifacts for $(pkg.name)"
                 artifact_dict = Pkg.Artifacts.load_artifacts_toml(artifacts_toml_path)
                 for name in keys(artifact_dict)
+                    if !include_lazy_artifacts &&
+                            isa(artifact_dict[name], AbstractDict) &&
+                            get(artifact_dict[name], "lazy", false)
+                        @info "skipping lazy artifact \"$name\""
+                        continue
+                    end
                     meta = Pkg.Artifacts.artifact_meta(name, artifacts_toml_path)
                     meta == nothing && continue
                     @debug "  \"$name\""


### PR DESCRIPTION
This pull request reconstitutes @rbvermaa's stab at https://github.com/JuliaLang/PackageCompiler.jl/issues/464 in https://github.com/RelationalAI-oss/PackageCompiler.jl/tree/rv-include-lazy. Rob notes

> I tried to add an include_lazy_artifacts option [1], however, it is probably not a correct solution, as it ignores the situation where there is a Dict in the Artifact section. See first part of the if at https://github.com/RelationalAI-oss/PackageCompiler.jl/blob/rv-include-lazy/src/PackageCompiler.jl#L722 .

which I haven't looked into yet. But putting this pull request up to get the ball rolling :).

Co-Authored-By: Rob Vermaas <rob.vermaas@gmail.com>