### PR TITLE
remove `Base.@ccallable` from doc examples

### DIFF
--- a/docs/src/devdocs/binaries_part_2.md
+++ b/docs/src/devdocs/binaries_part_2.md
@@ -19,8 +19,8 @@ section (e.g. the `julia-config.jl` script) but it is good to know they exist.
 
 A rough outline of the steps we will take to create an executable are:
 
-- Create our Julia app with a `Base.@ccallable` entry-point which means the Julia
-  function can be called directly from C.
+- Create our Julia app with a `julia_main()::Cint` entry-point which can be
+  called directly from C.
 - Create a custom sysimage to reduce latency (this is pretty much just doing
   part 1) and to hold the C-callable function from the first step.
 - Write an embedding wrapper in C that loads our custom sysimage, does some
@@ -39,7 +39,7 @@ module MyApp
 
 using CSV
 
-Base.@ccallable function julia_main()::Cint
+function julia_main()::Cint
     try
         real_main()
     catch
@@ -66,12 +66,10 @@ end
 end # module
 ```
 
-The function `julia_main` has been annotated with `Base.@ccallable` which means
-that a function with the unmangled name will appear in the sysimage. This
-function is just a small wrapper function that calls out to `real_main` which
-does the actual work.  All the code that is executed is put inside a try-catch
-block since the error will otherwise happen in the C-code where the backtrace
-is not very good
+The function `julia_main` is just a small wrapper function that calls out to
+`real_main` which does the actual work.  All the code that is executed is put
+inside a try-catch block since the error will otherwise happen in the C-code
+where the backtrace is not very good.
 
 To facilitate testing, we [check if the file was directly
 executed](https://docs.julialang.org/en/v1/manual/faq/#How-do-I-check-if-the-current-file-is-being-run-as-the-main-script?-1)

--- a/docs/src/devdocs/relocatable_part_3.md
+++ b/docs/src/devdocs/relocatable_part_3.md
@@ -81,7 +81,7 @@ The code for the app itself is quite simple:
 module MyApp
 using Crayons
 
-Base.@ccallable function julia_main()::Cint
+function julia_main()::Cint
     try
         real_main()
     catch
@@ -108,9 +108,11 @@ function real_main()
     end
     return 0
 end
+
 if abspath(PROGRAM_FILE) == @__FILE__
     real_main()
 end
+
 end # module
 ```
 

--- a/docs/src/upgrade.md
+++ b/docs/src/upgrade.md
@@ -32,7 +32,7 @@ to your project file.
 ### Executables
 - The function to create an executable is now called [`create_app`](@ref) instead of `build_executable`.
 - The `julia_main` function for executables should no longer take any arguments
-  (just access the global `ARGS`) and no longer need to be annotated with
+  (just access the global `ARGS`) and no longer should be annotated with
   `Base.@ccallable`.
 - The code for an executable need to be structured as a package, that is, with a
   `Project.toml` file and a `src/Package.jl` file etc.


### PR DESCRIPTION
After upgrading from julia 1.5 to 1.6 my app was no longer compiling, with the error:

```
ERROR: @ccallable was already defined for this method name
```

In the docs I then read that this annotation is no longer needed, however I still saw it in use in the docs. Hence I now remove the annotation from the docs.

For reference, a C callable function is still created, but it wraps the module's `julia_main`, see
https://github.com/JuliaLang/PackageCompiler.jl/blob/929657b22f3350ff1ed631ceb27dc6a715ef9a37/src/PackageCompiler.jl#L283-L293