### PR TITLE
add the docs for `create_library` to the manual

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -10,6 +10,7 @@ makedocs(
 
         "Manual" => [
             "sysimages.md"
+            "libs.md"
             "apps.md"
         ],
 


### PR DESCRIPTION
I think this was missed in https://github.com/JuliaLang/PackageCompiler.jl/pull/490 @kmsquire?