### PR TITLE
Propogate ARGS into precompile_execution_file

### DIFF
--- a/src/PackageCompiler.jl
+++ b/src/PackageCompiler.jl
@@ -247,6 +247,7 @@ function run_precompilation_script(project::String, sysimg::String, precompile_f
     touch(tracefile)
     cmd = `$(get_julia_cmd()) --sysimage=$(sysimg) --project=$project
             --compile=all --trace-compile=$tracefile $arg`
+    push!(cmd.exec, ARGS...)
     @debug "run_precompilation_script: running $cmd"
     precompile_file === nothing || @info "===== Start precompile execution ====="
     run(cmd)  # `Run` this command so that we'll display stdout from the user's script.


### PR DESCRIPTION
The patch provides delivering of the Julia arguments into the children process which is used for precompiling execution files.

```bash
julia --project=@. --startup-file=no -e '
using PackageCompiler;
PackageCompiler.create_app(pwd(), "bin";
    precompile_execution_file=["src/run.jl"])
' create some_task
```

instead of:
```bash
julia --project=@. --startup-file=no --trace-compile=build/precompile_statements.jl src/run.jl create some_task

julia --project=@. --startup-file=no -e '
using PackageCompiler;
PackageCompiler.create_app(pwd(), "bin";
    precompile_statements_file=["build/precompile_statements.jl"])
'
```