### PR TITLE
Disable autoprecomp during project instantiation

### DIFF
--- a/src/PackageCompiler.jl
+++ b/src/PackageCompiler.jl
@@ -503,7 +503,11 @@ function create_sysimage(packages::Union{Symbol, Vector{Symbol}}=Symbol[];
     # Instantiate the project
     ctx = create_pkg_context(project)
     @debug "instantiating project at $(repr(project))"
-    Pkg.instantiate(ctx, verbose=true)
+    if VERSION >= v"1.6.0-DEV.1673"
+        Pkg.instantiate(ctx, verbose=true, allow_autoprecomp = false)
+    else
+        Pkg.instantiate(ctx, verbose=true)
+    end
 
     check_packages_in_project(ctx, packages)
 


### PR DESCRIPTION
* This was previously done for one call to instantiate(), but not to a second
  call.  Without this, precompilation is failing for most packages
  in `create_app()` or `create_lib()`.

The previous change was in #476.  There, disabling precompilation fixed a deadlock on Ubuntu, but didn't seem to have a visible effect on OSX.  Here, it fixes precompilation on OSX (at least).  I'm also unsure why it's necessary.

Cc: @IanButterworth @KristofferC 