### PR TITLE
Fix compiler warning in julia_init.c during create_library()

### DIFF
--- a/src/julia_init.c
+++ b/src/julia_init.c
@@ -55,11 +55,11 @@ void set_depot_path(char *sysimage_path)
 #endif
     int depot_dir_len = strlen(depot_subdir);
 
-    int full_path_len = root_dir_len + depot_dir_len;
-    char *dir = malloc(full_path_len + 1);
+    int full_path_len = root_dir_len + depot_dir_len + 1;
+    char *dir = malloc(full_path_len);
 
-    strncpy(dir, root_dir, root_dir_len);
-    strncpy(dir + root_dir_len, depot_subdir, depot_dir_len);
+    strncpy(dir, root_dir, full_path_len);
+    strncpy(dir + root_dir_len, depot_subdir, full_path_len - root_dir_len);
     dir[full_path_len] = '\0';
 
 #ifdef _WIN32


### PR DESCRIPTION
For strncpy, the length should be based on the length of the
destination, not the length of the source.

(In this case, the length of the detination was determined based
on the length of the source, so it wasn't a problem in reality,
but it's easy enough to silence the compiler warning.)

Fixes #532