### PR TITLE
put the sysimage for apps inside lib and slightly tweak rpath

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "PackageCompiler"
 uuid = "9b87118b-4619-50d2-8e1e-99f35a4d4d9d"
-version = "1.4.1"
+version = "1.4.2"
 
 [deps]
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
@@ -8,7 +8,7 @@ Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [compat]
-julia = "1.3.1"
+julia = "1.6"
 
 [extras]
 Example = "7876af07-990d-54b4-ab0e-23690620f79a"

--- a/src/juliaconfig.jl
+++ b/src/juliaconfig.jl
@@ -73,20 +73,14 @@ function cflags()
     return String(take!(flags))
 end
 
-function rpath()
-    Sys.iswindows() && return ``
+function rpath_executable()
+    Sys.iswindows() ? `` :
+    Sys.isapple()   ? `-Wl,-rpath,'@executable_path/../lib' -Wl,-rpath,'@executable_path/../lib/julia'` :
+                      `-Wl,-rpath,\$ORIGIN/../lib:\$ORIGIN/../lib/julia`
+end
 
-    if VERSION >= v"1.6.0-DEV.1673"
-        if Sys.isapple()
-            `-Wl,-rpath,'@executable_path' -Wl,-rpath,'@executable_path/../lib' -Wl,-rpath,'@executable_path/../lib/julia'`
-        else
-            `-Wl,-rpath,\$ORIGIN:\$ORIGIN/../lib:\$ORIGIN/../lib/julia`
-        end
-    else
-        if Sys.isapple()
-            `-Wl,-rpath,'@executable_path' -Wl,-rpath,'@executable_path/../lib'`
-        else
-            `-Wl,-rpath,\$ORIGIN:\$ORIGIN/../lib`
-        end
-    end
+function rpath_sysimage()
+    Sys.iswindows() ? `` :
+    Sys.isapple()   ? `-Wl,-rpath,'@executable_path' -Wl,-rpath,'@executable_path/julia'` :
+                      `-Wl,-rpath,\$ORIGIN:\$ORIGIN/julia`
 end


### PR DESCRIPTION
this allows the sysimage in `create_library` to not live in a folder called `lib` which is sometimes useful

Previously, if one renamed the `lib` folder that is created by `create_library`, the dynamic linker would not find e.g. `libjulia-internal` since it looked in `../lib/julia`. Now it just looks in `./julia`.