### PR TITLE
hide the "devdocs" in the manual

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -19,12 +19,14 @@ makedocs(
             "examples/plots.md",
         ],
 
+        #=
         "PackageCompiler - the manual way" => [
             "devdocs/intro.md",
             "devdocs/sysimages_part_1.md",
             "devdocs/binaries_part_2.md",
             "devdocs/relocatable_part_3.md",
         ],
+        =#
 
         "References" => "refs.md",
         "Upgrade notes" => "upgrade.md",


### PR DESCRIPTION
I am not sure these are very useful to have anymore. They are slowly becoming outdated and most people just seem confused about if they should use the stuff written in there over the normal PackageCompiler interface.