### PR TITLE
give packages as strings instead of symbols

### DIFF
--- a/docs/src/examples/ohmyrepl.md
+++ b/docs/src/examples/ohmyrepl.md
@@ -39,7 +39,7 @@ These are functions that Julia compiled. We now just tell `create_sysimage` to
 use these precompile statements when creating the system image:
 
 ```julia
-PackageCompiler.create_sysimage(:OhMyREPL; precompile_statements_file="ohmyrepl_precompile.jl", replace_default=true)
+PackageCompiler.create_sysimage("OhMyREPL"; precompile_statements_file="ohmyrepl_precompile.jl", replace_default=true)
 ```
 
 Restart julia and start typing something. If everything went well you should

--- a/docs/src/examples/plots.md
+++ b/docs/src/examples/plots.md
@@ -30,7 +30,7 @@ The custom sysimage is then created as:
 
 ```julia
 using PackageCompiler
-create_sysimage(:Plots, sysimage_path="sys_plots.so", precompile_execution_file="precompile_plots.jl")
+create_sysimage("Plots", sysimage_path="sys_plots.so", precompile_execution_file="precompile_plots.jl")
 ```
 
 If we now start Julia with the flag `--sysimage sys_plots.so` and re-time our previous commands:

--- a/docs/src/sysimages.md
+++ b/docs/src/sysimages.md
@@ -77,7 +77,7 @@ Activating new environment at `~/NewSysImageEnv/Project.toml`
   Updating `~/NewSysImageEnv/Manifest.toml`
   [7876af07] + Example v0.5.3
 
-julia> create_sysimage(:Example; sysimage_path="ExampleSysimage.so")
+julia> create_sysimage("Example"; sysimage_path="ExampleSysimage.so")
 [ Info: PackageCompiler: creating system image object file, this might take a while...
 
 julia> exit()
@@ -107,7 +107,7 @@ such as Julia-VSCode.** Replacing the default sysimage is done by omitting the
 ```julia
 # This is not recommended and may cause compatability issues since external
 # packages such as Julia-VSCode may depend on the default sysimage.
-create_sysimage([:Debugger, :OhMyREPL]; replace_default=true)
+create_sysimage(["Debugger", "OhMyREPL"]; replace_default=true)
 ```
 
 If this is the first time `create_sysimage` is called with `replace_default`, a
@@ -170,7 +170,7 @@ julia> using PackageCompiler
 (v1.3) pkg> activate .
 Activating environment at `~/NewSysImageEnv/Project.toml`
 
-julia> PackageCompiler.create_sysimage(:Example; sysimage_path="ExampleSysimagePrecompile.so",
+julia> PackageCompiler.create_sysimage("Example"; sysimage_path="ExampleSysimagePrecompile.so",
                                          precompile_execution_file="precompile_example.jl")
 [ Info: PackageCompiler: creating system image object file, this might take a while...
 

--- a/src/PackageCompiler.jl
+++ b/src/PackageCompiler.jl
@@ -398,11 +398,12 @@ function check_packages_in_project(ctx, packages)
 end
 
 """
-    create_sysimage(packages::Union{Symbol, Vector{Symbol}}; kwargs...)
+    create_sysimage(packages::Union{String, Vector{String}}; kwargs...)
 
-Create a system image that includes the package(s) in `packages`.  An attempt
-to automatically find a compiler will be done but can also be given explicitly
-by setting the environment variable `JULIA_CC` to a path to a compiler
+Create a system image that includes the package(s) in `packages` (given as a
+string or vector).  An attempt to automatically find a compiler will be done but
+can also be given explicitly by setting the environment variable `JULIA_CC` to a
+path to a compiler
 
 ### Keyword arguments:
 
@@ -446,7 +447,7 @@ by setting the environment variable `JULIA_CC` to a path to a compiler
 
 - `script::String`: Path to a file that gets executed in the `--output-o` process.
 """
-function create_sysimage(packages::Union{Symbol, Vector{Symbol}}=Symbol[];
+function create_sysimage(packages::Union{Symbol, String, Vector{String}, Vector{Symbol}}=String[];
                          sysimage_path::Union{String,Nothing}=nothing,
                          project::String=dirname(active_project()),
                          precompile_execution_file::Union{String, Vector{String}}=String[],
@@ -936,10 +937,10 @@ function _create_app(package_dir::String,
             # by first creating a normal "empty" sysimage and then use that to finally create the one
             # with the @ccallable function
             tmp_base_sysimage = joinpath(tmp, "tmp_sys.so")
-            create_sysimage(Symbol[]; sysimage_path=tmp_base_sysimage, project=package_dir,
+            create_sysimage(String[]; sysimage_path=tmp_base_sysimage, project=package_dir,
                             incremental=false, filter_stdlibs, cpu_target)
 
-            create_sysimage(Symbol(sysimg_name); sysimage_path=sysimg_file, project=package_dir,
+            create_sysimage(sysimg_name; sysimage_path=sysimg_file, project=package_dir,
                             incremental=true,
                             precompile_execution_file,
                             precompile_statements_file,
@@ -950,15 +951,15 @@ function _create_app(package_dir::String,
                             version,
                             soname)
         else
-            create_sysimage(Symbol(sysimg_name); sysimage_path=sysimg_file, project=package_dir,
-                                              incremental, filter_stdlibs,
-                                              precompile_execution_file,
-                                              precompile_statements_file,
-                                              cpu_target,
-                                              isapp,
-                                              julia_init_c_file,
-                                              version,
-                                              soname)
+            create_sysimage(sysimg_name; sysimage_path=sysimg_file, project=package_dir,
+                                         incremental, filter_stdlibs,
+                                         precompile_execution_file,
+                                         precompile_statements_file,
+                                         cpu_target,
+                                         isapp,
+                                         julia_init_c_file,
+                                         version,
+                                         soname)
         end
 
         if Sys.isapple()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -31,7 +31,7 @@ end
     sysimage_path = joinpath(tmp, "sys." * Libdl.dlext)
     script = tempname()
     write(script, "script_func() = println(\"I am a script\")")
-    create_sysimage(:Example; sysimage_path=sysimage_path,
+    create_sysimage("Example"; sysimage_path=sysimage_path,
                               project=new_project,
                               precompile_execution_file=joinpath(@__DIR__, "precompile_execution.jl"),
                               precompile_statements_file=joinpath.(@__DIR__, ["precompile_statements.jl",


### PR DESCRIPTION
But keep backward compatibility with symbols.

It doesn't really make sense to use symbols for the provided packages. I think the reason for this is because the old PackageCompiler used it. However, if you want to include e.g. `MKL_jll` in your sysimage you have to specify `Symbol("MKL_jll")`. So I think encouraging the more flexible strings makes sense to have as the recommended API.