### PR TITLE
call `create_sysimage` with a vector for packages

### DIFF
--- a/docs/src/examples/ohmyrepl.md
+++ b/docs/src/examples/ohmyrepl.md
@@ -39,7 +39,7 @@ These are functions that Julia compiled. We now just tell `create_sysimage` to
 use these precompile statements when creating the system image:
 
 ```julia
-PackageCompiler.create_sysimage("OhMyREPL"; precompile_statements_file="ohmyrepl_precompile.jl", replace_default=true)
+PackageCompiler.create_sysimage(["OhMyREPL"]; precompile_statements_file="ohmyrepl_precompile.jl", replace_default=true)
 ```
 
 Restart Julia and start typing something. If everything went well you should

--- a/docs/src/examples/plots.md
+++ b/docs/src/examples/plots.md
@@ -30,7 +30,7 @@ The custom sysimage is then created as:
 
 ```julia
 using PackageCompiler
-create_sysimage("Plots", sysimage_path="sys_plots.so", precompile_execution_file="precompile_plots.jl")
+create_sysimage(["Plots"], sysimage_path="sys_plots.so", precompile_execution_file="precompile_plots.jl")
 ```
 
 If we now start Julia with the flag `--sysimage sys_plots.so` and re-time our previous commands:

--- a/docs/src/sysimages.md
+++ b/docs/src/sysimages.md
@@ -77,7 +77,7 @@ Activating new environment at `~/NewSysImageEnv/Project.toml`
   Updating `~/NewSysImageEnv/Manifest.toml`
   [7876af07] + Example v0.5.3
 
-julia> create_sysimage("Example"; sysimage_path="ExampleSysimage.so")
+julia> create_sysimage(["Example"]; sysimage_path="ExampleSysimage.so")
 [ Info: PackageCompiler: creating system image object file, this might take a while...
 
 julia> exit()
@@ -170,7 +170,7 @@ julia> using PackageCompiler
 (v1.3) pkg> activate .
 Activating environment at `~/NewSysImageEnv/Project.toml`
 
-julia> PackageCompiler.create_sysimage("Example"; sysimage_path="ExampleSysimagePrecompile.so",
+julia> PackageCompiler.create_sysimage(["Example"]; sysimage_path="ExampleSysimagePrecompile.so",
                                        precompile_execution_file="precompile_example.jl")
 
 [ Info: PackageCompiler: creating system image object file, this might take a while...

--- a/src/PackageCompiler.jl
+++ b/src/PackageCompiler.jl
@@ -406,7 +406,7 @@ function check_packages_in_project(ctx, packages)
 end
 
 """
-    create_sysimage(packages::Union{String, Vector{String}}; kwargs...)
+    create_sysimage(packages::Vector{String}; kwargs...)
 
 Create a system image that includes the package(s) in `packages` given as a
 string or vector). An attempt to automatically find a compiler will be done but
@@ -458,7 +458,7 @@ path to a compiler.
 - `sysimage_build_args::Cmd`: A set of command line options that is used in the Julia process building the sysimage,
   for example `-O1 --check-bounds=yes`.
 """
-function create_sysimage(packages::Union{Symbol, String, Vector{String}, Vector{Symbol}}=String[];
+function create_sysimage(packages::Union{Symbol, Vector{String}, Vector{Symbol}}=String[];
                          sysimage_path::Union{String,Nothing}=nothing,
                          project::String=dirname(active_project()),
                          precompile_execution_file::Union{String, Vector{String}}=String[],
@@ -969,7 +969,7 @@ function _create_app(package_dir::String,
             create_sysimage(String[]; sysimage_path=tmp_base_sysimage, project=package_dir,
                             incremental=false, filter_stdlibs, cpu_target)
 
-            create_sysimage(sysimg_name; sysimage_path=sysimg_file, project=package_dir,
+            create_sysimage([sysimg_name]; sysimage_path=sysimg_file, project=package_dir,
                             incremental=true,
                             precompile_execution_file,
                             precompile_statements_file,
@@ -981,7 +981,7 @@ function _create_app(package_dir::String,
                             soname,
                             sysimage_build_args)
         else
-            create_sysimage(sysimg_name; sysimage_path=sysimg_file, project=package_dir,
+            create_sysimage([sysimg_name]; sysimage_path=sysimg_file, project=package_dir,
                                          incremental, filter_stdlibs,
                                          precompile_execution_file,
                                          precompile_statements_file,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -35,7 +35,7 @@ end
     opt_during_sysimage = Base.JLOptions().opt_level
     print_opt() = println("opt: -O\$opt_during_sysimage")
     """)
-    create_sysimage("Example"; sysimage_path=sysimage_path,
+    create_sysimage(["Example"]; sysimage_path=sysimage_path,
                               project=new_project,
                               precompile_execution_file=joinpath(@__DIR__, "precompile_execution.jl"),
                               precompile_statements_file=joinpath.(@__DIR__, ["precompile_statements.jl",


### PR DESCRIPTION
Prepare for `create_sysimage(project::String)` to give a path to a project to create a sysimage. `create_sysimage(package::String)` has not yet been on a release.