### PR TITLE
include transitive dependencies into sysimage by default

### DIFF
--- a/docs/src/examples/plots.md
+++ b/docs/src/examples/plots.md
@@ -9,10 +9,13 @@ the default sysimage:
 
 ```julia-repl
 julia> @time using Plots
-  5.284989 seconds (5.22 M allocations: 308.954 MiB, 1.41% gc time)
+  2.943946 seconds (8.11 M allocations: 567.656 MiB, 6.47% gc time)
 
-julia> @time (p = plot(rand(5), rand(5)); display(p))
-  13.769197 seconds (18.42 M allocations: 909.963 MiB, 1.75% gc time)
+julia> @time p = plot(rand(2,2));
+  1.940742 seconds (3.29 M allocations: 197.525 MiB, 4.65% gc time)
+
+julia> @time display(p);
+  5.132217 seconds (15.00 M allocations: 847.491 MiB, 2.57% gc time, 45.95%)
 ```
 
 This is approximately 19 seconds from the start of Julia to the first plot.
@@ -22,7 +25,7 @@ We now create a precompilation file with exactly this workload in a file called 
 
 ```julia
 using Plots
-p = plot(rand(5), rand(5))
+p = plot(rand(2,2))
 display(p)
 ```
 
@@ -37,23 +40,26 @@ If we now start Julia with the flag `--sysimage sys_plots.so` and re-time our pr
 
 ```julia-repl
 julia> @time using Plots
-  0.000826 seconds (852 allocations: 42.125 KiB)
+  0.000159 seconds (1.07 k allocations: 79.797 KiB)
 
-julia> @time (p = plot(rand(5), rand(5)); display(p))
-  0.139642 seconds (468.42 k allocations: 12.176 MiB)
+julia> @time p = plot(rand(2,2));
+  0.037670 seconds (74.09 k allocations: 4.703 MiB)
+
+julia> @time display(p);
+  0.331869 seconds (278.38 k allocations: 7.900 MiB)
 ```
 
 which is a sizeable speedup.
 
 Note that since we have more stuff in our sysimage, Julia is slightly slower to
-start (0.04 seconds on this machine):
+start (0.35 seconds on this machine):
 
 ```
 # Default sysimage
-➜ time julia -e ''
-    0.13s user 0.08s system 88% cpu 0.232 total
+➜ time julia -e ''                        
+julia -e ''  0.06s user 0.06s system 130% cpu 0.088 total
 
 # Custom sysimage
 ➜ time julia --sysimage sys_plots.so -e ''
-    0.17s user 0.10s system 94% cpu 0.284 total
+julia --sysimage sys_plots.so -e ''  0.43s user 0.30s system 347% cpu 0.211 total
 ```

--- a/examples/MyApp/Project.toml
+++ b/examples/MyApp/Project.toml
@@ -4,6 +4,7 @@ authors = ["Kristoffer Carlsson <kristoffer.carlsson@juliacomputing.com>"]
 version = "0.1.0"
 
 [deps]
+Crayons = "a8cc5b0e-0ffa-5ad4-8c14-923d3ee1735f"
 Example = "7876af07-990d-54b4-ab0e-23690620f79a"
 HelloWorldC_jll = "dca1746e-5efc-54fc-8249-22745bc95a49"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"

--- a/examples/MyApp/precompile_app.jl
+++ b/examples/MyApp/precompile_app.jl
@@ -2,3 +2,8 @@ using MyApp
 
 push!(ARGS, "arg")
 MyApp.julia_main()
+
+using Example
+Example.hello("PackageCompiler")
+
+using Crayons

--- a/examples/MyApp/src/MyApp.jl
+++ b/examples/MyApp/src/MyApp.jl
@@ -1,5 +1,6 @@
 module MyApp
 
+using Base: is_core_macro
 using Example
 using HelloWorldC_jll
 using Pkg.Artifacts
@@ -14,6 +15,10 @@ function julia_main()
         return 1
     end
     return 0
+end
+
+function is_crayons_loaded()
+    Base.PkgId(Base.UUID("a8cc5b0e-0ffa-5ad4-8c14-923d3ee1735f"), "Crayons") in keys(Base.loaded_modules)
 end
 
 function real_main()
@@ -38,6 +43,8 @@ function real_main()
         run(`$x`)
     end
     println()
+
+    @show is_crayons_loaded()
 
     println("Running the artifact")
     res = read(`$(fooifier_path()) 5 10`, String)

--- a/examples/MyApp/src/MyApp.jl
+++ b/examples/MyApp/src/MyApp.jl
@@ -1,6 +1,5 @@
 module MyApp
 
-using Base: is_core_macro
 using Example
 using HelloWorldC_jll
 using Pkg.Artifacts

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -96,6 +96,8 @@ end
             @test occursin("(Base.JLOptions()).opt_level = 2", app_output)
             @test occursin("(Base.JLOptions()).nthreads = 3", app_output)
             @test occursin("(Base.JLOptions()).check_bounds = 1", app_output)
+            # Check transitive inclusion of dependencies
+            @test occursin("is_crayons_loaded() = true", app_output)
         end
     end
 


### PR DESCRIPTION
Closes https://github.com/JuliaLang/PackageCompiler.jl/pull/463. #463 only dealt with the case of adding all top-level dependencies to a sysimage but this also recurses down into the other dependencies Needed for e.g. https://github.com/JuliaLang/PackageCompiler.jl/pull/463#issuecomment-926603889.

cc @NHDaly 