### PR TITLE
Don't warn if modules already loaded during precompilation

### DIFF
--- a/src/PackageCompiler.jl
+++ b/src/PackageCompiler.jl
@@ -507,7 +507,15 @@ function create_sysimage(packages::Union{Symbol, Vector{String}, Vector{Symbol}}
     # Need to ensure that Pkg can find the source location of the packages:
     copy!(LOAD_PATH, [project])
     try
-        Pkg.instantiate(ctx, verbose=true, allow_autoprecomp = true)
+        Pkg.instantiate(ctx, verbose=true, allow_autoprecomp = false)
+        try
+            # try to disable warning about precompiling packages that are already loaded given work will be done in new
+            # julia sessions. The `warn_loaded` kwarg was introduced in https://github.com/JuliaLang/Pkg.jl/pull/2739
+            # so isn't present on all versions, so try and do standard precompilation if fails
+            Pkg.precompile(ctx, warn_loaded = false)
+        catch
+            Pkg.precompile(ctx)
+        end
     finally
         copy!(LOAD_PATH, old_load_path)
     end


### PR DESCRIPTION
Given the work is done in a new process, the warnings about packages already being loaded during `Pkg.precompile` are unnecessary.

Fixed in https://github.com/JuliaLang/Pkg.jl/pull/2739 with the introduction of `Pkg.precompile(warn_loaded = false)`, so not in older versions or backported yet.

I used a try catch approach which might be suboptimal.
Is there a better way to check for the presence of a kwarg in a method? Otherwise a julia version check could be done.

For example the error that's thrown in 1.6.3 is this because the kwarg is collected by `kwarg...`

```
julia> Pkg.precompile(warn_loaded = false)
ERROR: type Context has no field warn_loaded
Stacktrace:
 [1] #Context!#40
   @ /Users/julia/buildbot/worker/package_macos64/build/usr/share/julia/stdlib/v1.6/Pkg/src/Types.jl:427 [inlined]
 [2] precompile(ctx::Pkg.Types.Context; internal_call::Bool, strict::Bool, kwargs::Base.Iterators.Pairs{Symbol, Bool, Tuple{Symbol}, NamedTuple{(:warn_loaded,), Tuple{Bool}}})
   @ Pkg.API /Users/julia/buildbot/worker/package_macos64/build/usr/share/julia/stdlib/v1.6/Pkg/src/API.jl:921
 [3] #precompile#196
   @ /Users/julia/buildbot/worker/package_macos64/build/usr/share/julia/stdlib/v1.6/Pkg/src/API.jl:919 [inlined]
 [4] top-level scope
   @ REPL[2]:1
```