### PR TITLE
require packages to make their entry functions for app ccallable

### DIFF
--- a/docs/src/apps.md
+++ b/docs/src/apps.md
@@ -79,7 +79,7 @@ The source of an app is a package with a project and manifest file.
 It should define a function with the signature
 
 ```julia
-function julia_main()::Cint
+Base.@ccallable function julia_main()::Cint
   # do something based on ARGS?
   return 0 # if things finished successfully
 end

--- a/examples/MyApp/src/MyApp.jl
+++ b/examples/MyApp/src/MyApp.jl
@@ -6,7 +6,7 @@ using Pkg.Artifacts
 
 fooifier_path() = joinpath(artifact"fooifier", "bin", "fooifier" * (Sys.iswindows() ? ".exe" : ""))
 
-function julia_main()
+Base.@ccallable function julia_main()::Cint
     try
         real_main()
     catch

--- a/src/PackageCompiler.jl
+++ b/src/PackageCompiler.jl
@@ -354,24 +354,6 @@ function create_sysimg_object_file(object_file::String,
         """)
     end
 
-    if isapp
-        # If it is an app, there is only one packages
-        @assert length(packages) == 1
-        app_start_code = """
-        Base.@ccallable function julia_main()::Cint
-            try
-                $(packages[1]).julia_main()
-            catch
-                Core.print("julia_main() threw an unhandled exception")
-                return 1
-            end
-        end
-        """
-        print(julia_code_buffer, app_start_code)
-    end
-
-
-
     print(julia_code_buffer, """
         empty!(LOAD_PATH)
         empty!(DEPOT_PATH)


### PR DESCRIPTION
The current way of specifying the main is due to a workaround for https://github.com/JuliaLang/julia/issues/34076. However, with that fixed, we should go back to the original way which doesn't require us to inject these ccallables ourselves.