### PR TITLE
remove calling `libsupport_init`, this is done automatically by `julia_init`

### DIFF
--- a/docs/src/devdocs/binaries_part_2.md
+++ b/docs/src/devdocs/binaries_part_2.md
@@ -167,9 +167,6 @@ int main(int argc, char *argv[])
 {
     uv_setup_args(argc, argv);
 
-    // initialization
-    libsupport_init();
-
     // JULIAC_PROGRAM_LIBNAME defined on command-line for compilation
     jl_options.image_file = JULIAC_PROGRAM_LIBNAME;
     julia_init(JL_IMAGE_JULIA_HOME);

--- a/src/embedding_wrapper.c
+++ b/src/embedding_wrapper.c
@@ -45,9 +45,6 @@ int main(int argc, char *argv[])
         jl_parse_opts(&julia_argc, &julia_argv);
     }
 
-    // initialization
-    libsupport_init();
-
     // Get the current exe path so we can compute a relative depot path
     char *exe_path = (char*)malloc(PATH_MAX);
     size_t path_size = PATH_MAX;

--- a/src/julia_init.c
+++ b/src/julia_init.c
@@ -17,7 +17,6 @@ JL_DLLEXPORT char *dirname(char *);
 void setup_args(int argc, char **argv)
 {
     uv_setup_args(argc, argv);
-    libsupport_init();
     jl_parse_opts(&argc, &argv);
 }
 


### PR DESCRIPTION
https://github.com/JuliaLang/julia/blob/628209c1f2f746e3fc21ccd7cb34e67289403d44/src/init.c#L629