### PR TITLE
improve artifact bundling

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,6 +3,7 @@ uuid = "9b87118b-4619-50d2-8e1e-99f35a4d4d9d"
 version = "1.7.0"
 
 [deps]
+Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
 LazyArtifacts = "4af54fe1-eca0-43a8-85a7-787d91b784e3"
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
@@ -10,8 +11,8 @@ RelocatableFolders = "05181044-ff0b-4ac5-8273-598c1e38db00"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [compat]
-julia = "1.6"
 RelocatableFolders = "0.1"
+julia = "1.6"
 
 [extras]
 Example = "7876af07-990d-54b4-ab0e-23690620f79a"


### PR DESCRIPTION
I noticed we were bundling all artifacts (even those whose artifacts did not exist for our platform).

Uses more of the Pkg API to avoid mistakes like this.