### PR TITLE
allow loading stdlibs in the precompile process

### DIFF
--- a/examples/MyApp/precompile_app.jl
+++ b/examples/MyApp/precompile_app.jl
@@ -7,3 +7,7 @@ using Example
 Example.hello("PackageCompiler")
 
 using Crayons
+
+# It is ok to use stdlibs that are not in the project dependencies
+using Test
+@test 1==1

--- a/src/PackageCompiler.jl
+++ b/src/PackageCompiler.jl
@@ -256,7 +256,8 @@ function run_precompilation_script(project::String, sysimg::String, precompile_f
     cmd = `$(get_julia_cmd()) --sysimage=$(sysimg)
             --compile=all --trace-compile=$tracefile $arg`
     # --project is not propagated well with Distributed, so use environment
-    cmd = addenv(cmd, "JULIA_LOAD_PATH" => project)
+    splitter = Sys.iswindows() ? ';' : ':'
+    cmd = addenv(cmd, "JULIA_LOAD_PATH" => "$project$(splitter)@stdlib")
     precompile_file === nothing || @info "PackageCompiler: Executing $(precompile_file) => $(tracefile)"
     run(cmd)  # `Run` this command so that we'll display stdout from the user's script.
     precompile_file === nothing || @info "PackageCompiler: Done"


### PR DESCRIPTION
Some people e.g. run parts of their tests in the precompile script. No real harm in allowing them to keep loading the stdlibs. 