### PR TITLE
Fix a typo while gathering dependencies from Manifest.toml

### DIFF
--- a/src/PackageCompiler.jl
+++ b/src/PackageCompiler.jl
@@ -579,7 +579,7 @@ function create_sysimage(packages::Union{Symbol, Vector{String}, Vector{Symbol}}
                 deps = if ctx.env.pkg !== nothing && pkgid.uuid == ctx.env.pkg.uuid
                     ctx.env.project.deps
                 else
-                    ctx.env.manifest.deps[pkgid.uuid].deps
+                    ctx.env.manifest[pkgid.uuid].deps
                 end
                 pkgid_deps = [Base.PkgId(uuid, name) for (name, uuid) in deps]
                 for pkgid_dep in pkgid_deps


### PR DESCRIPTION
I got this error while using the 1.7.1 release:

```
ERROR: type Dict has no field deps
Stacktrace:
 [1] getproperty(x::Dict{Base.UUID, Pkg.Types.PackageEntry}, f::Symbol)
   @ Base ./Base.jl:33
 [2] create_sysimage(packages::Vector{String}; sysimage_path::String, project::String, precompile_execution_file::Vector{String}, precompile_statements_file::Vector{String}, incremental::Bool, filter_stdlibs::Bool, replace_default::Bool, cpu_target::String, script::Nothing, sysimage_build_args::Cmd, include_transitive_dependencies::Bool, base_sysimage::Nothing, isapp::Bool, julia_init_c_file::Nothing, version::Nothing, compat_level::String, soname::Nothing)
   @ PackageCompiler ~/.julia/packages/PackageCompiler/PmmEa/src/PackageCompiler.jl:582
```

This was probably due to a type to typo as `ctx.env.manifest` is a `Dict`.

Perhaps the tests should also be updated?
