### PR TITLE
Fix the format of Artifacts.toml

### DIFF
--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -1,19 +1,19 @@
-[[mingw32]]
+[[mingw]]
 git-tree-sha1 = "fdff308295487f361ef6e8dc2d27f5abe8a6eee9"
 os = "windows"
 arch = "x86_64"
 lazy = true
 
-    [[mingw32.download]]
+    [[mingw.download]]
     sha256 = "fe3f401bc936fbe6af940b26c5e0f266f762a3416f979c706e599b24082dc5c7"
     url = "https://github.com/JuliaLang/PackageCompiler.jl/releases/download/v1.0.0/x86_64-8.1.0-release-posix-seh-rt_v6-rev0.tar.gz"
 
-[[mingw32]]
+[[mingw]]
 git-tree-sha1 = "bc760d8ef1b4840e55a36bd361587b4975af811f"
 os = "windows"
 arch = "i686"
 lazy = true
 
-    [[mingw32.download]]
+    [[mingw.download]]
     sha256 = "ab0abb76384ce9b657141d3a54150d0b865f9c06576caa7901a6c8429c9008e5"
     url = "https://github.com/JuliaLang/PackageCompiler.jl/releases/download/v1.0.0/i686-8.1.0-release-posix-sjlj-rt_v6-rev0.tar.gz"

--- a/src/PackageCompiler.jl
+++ b/src/PackageCompiler.jl
@@ -94,9 +94,9 @@ function run_compiler(cmd::Cmd)
     local compiler_cmd
     @static if Sys.iswindows()
         if Int === Int64
-            path = joinpath(LazyArtifacts.artifact"mingw32", "mingw64", "bin", "gcc.exe")
+            path = joinpath(LazyArtifacts.artifact"mingw", "mingw64", "bin", "gcc.exe")
         else
-            path = joinpath(LazyArtifacts.artifact"mingw32", "mingw32", "bin", "gcc.exe")
+            path = joinpath(LazyArtifacts.artifact"mingw", "mingw32", "bin", "gcc.exe")
         end
             compiler_cmd = `$path`
     end


### PR DESCRIPTION
I think that the `i868-w64-mingw32` entry in `Artifacts.toml` should be a table?

Otherwise `Artifacts.artifact_meta` does not filter the platform (something there for backward compatibility?), and this artefact gets downloaded on platforms other than windows, as long as  `include_lazy_artifacts` is `true`. 

https://github.com/JuliaLang/julia/blob/ae8452a9e0b973991c30f27beb2201db1b0ea0d3/stdlib/Artifacts/src/Artifacts.jl#L385-L397