### PR TITLE
call entry points in apps using the julia runtime instead of via `@ccallable`

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -80,8 +80,6 @@ PackageCompiler 2.0 comes with a few breaking changes.
 - The functionality for replacing the default sysimage (`replace_default=true`) has been removed. Instead, you can e.g. 
   create an alias or shortcut that starts Julia with a custom sysimage by specifying the `--sysimage=<PATH/TO/SYSIMAGE>` 
   command line option.
-- Apps now need to make their "main"-functions ccallable by adding `Base.@ccallable` before the function and `::Cint` as a return type,
-  for example `Base.@ccallable julia_main()::Cint ...`.
 - Lazy artifacts (those not downloaded until used) are not included in apps by default anymore. Use `include_lazy_artifacts=true` to re-enable this.
 - Passing no packages to `create_sysimage` will now include all packages in the given project instead of a syimage with no packages.
   Use `String[]` as a first argument if you want the old behavior.

--- a/docs/src/libs.md
+++ b/docs/src/libs.md
@@ -19,7 +19,7 @@ The library is expected to provide C-callable functions for the functionality it
 is providing, defined using the `Base.@ccallable` macro:
 
 ```julia
-Base.@ccallable function increment(count::Cint)::Cint
+function increment(count::Cint)::Cint
     count += 1
     println("Incremented count: $count")
     return count

--- a/examples/MyApp/src/MyApp.jl
+++ b/examples/MyApp/src/MyApp.jl
@@ -15,7 +15,7 @@ end
 
 fooifier_path() = joinpath(artifact"fooifier", "bin", "fooifier" * (Sys.iswindows() ? ".exe" : ""))
 
-Base.@ccallable function julia_main()::Cint
+function julia_main()::Cint
     try
         real_main()
     catch
@@ -25,10 +25,6 @@ Base.@ccallable function julia_main()::Cint
     return 0
 end
 
-Base.@ccallable function second_main()::Cint
-    println("Hello from second main")
-    return 0
-end
 
 function is_crayons_loaded()
     Base.PkgId(Base.UUID("a8cc5b0e-0ffa-5ad4-8c14-923d3ee1735f"), "Crayons") in keys(Base.loaded_modules)
@@ -89,5 +85,22 @@ end
 if abspath(PROGRAM_FILE) == @__FILE__
     real_main()
 end
+
+# Used for testing
+function second_main()::Cint
+    println("Hello from second main")
+    return 0
+end
+
+function wrong_return_type()
+    return "oops"
+end
+
+function erroring()
+    1 + "foo"
+    return 0
+end
+
+
 
 end # module


### PR DESCRIPTION
This has multiple advantages:

- we no longer have to link the executable with the sysimage, meaning that for Windows the sysimage can be in the same place as for normal julia (`lib/julia/sys.dll`).
- it also means we can give better error messages if a user does a mistake like missing to define the function, having an uncaught error in the function or returning a bad type
- we can avoid the `@ccallable` workaround bug which leads to faster app creation.