### PR TITLE
Fix code block on apps documentation

### DIFF
--- a/docs/src/apps.md
+++ b/docs/src/apps.md
@@ -281,3 +281,4 @@ CodeInfo(
 │          value@_16 = %8
 │   %10  = Base.repr(%8)
 ...
+```


### PR DESCRIPTION
The code block was broken on 2.0 docs 

![image](https://user-images.githubusercontent.com/32756941/140520384-a9b99afb-131e-4918-b74c-bb12088e04a7.png)
