### PR TITLE
Fix typo in docs: use correct default cpu target

### DIFF
--- a/src/PackageCompiler.jl
+++ b/src/PackageCompiler.jl
@@ -394,7 +394,7 @@ compiler (can also include extra arguments to the compiler, like `-g`).
    Keyword argument `incremental` must be `true` if `base_sysimage` is not `nothing`.
 
 - `cpu_target::String`: The value to use for `JULIA_CPU_TARGET` when building the system image. Defaults
-  to `nativea`.
+  to `native`.
 
 - `script::String`: Path to a file that gets executed in the `--output-o` process.
 


### PR DESCRIPTION
A very small typo, but it's annoying because it means the user could think they were asked to pass "nativea" instead of "native".