### PR TITLE
use debug libs when Julia is debug build

### DIFF
--- a/src/PackageCompiler.jl
+++ b/src/PackageCompiler.jl
@@ -543,7 +543,7 @@ function create_sysimg_from_object_file(object_files::Vector{String},
     # Prevent compiler from stripping all symbols from the shared lib.
     o_file_flags = Sys.isapple() ? `-Wl,-all_load $object_files` : `-Wl,--whole-archive $object_files -Wl,--no-whole-archive`
     extra = get_extra_linker_flags(version, compat_level, soname)
-    cmd = `$(bitflag()) $(march()) -shared -L$(julia_libdir()) -L$(julia_private_libdir()) -o $sysimage_path $o_file_flags $(ldlibs()) $extra`
+    cmd = `$(bitflag()) $(march()) -shared -L$(julia_libdir()) -L$(julia_private_libdir()) -o $sysimage_path $o_file_flags $(Base.shell_split(ldlibs())) $extra`
     run_compiler(cmd; cplusplus=true)
     return nothing
 end

--- a/src/PackageCompiler.jl
+++ b/src/PackageCompiler.jl
@@ -543,7 +543,7 @@ function create_sysimg_from_object_file(object_files::Vector{String},
     # Prevent compiler from stripping all symbols from the shared lib.
     o_file_flags = Sys.isapple() ? `-Wl,-all_load $object_files` : `-Wl,--whole-archive $object_files -Wl,--no-whole-archive`
     extra = get_extra_linker_flags(version, compat_level, soname)
-    cmd = `$(bitflag()) $(march()) -shared -L$(julia_libdir()) -L$(julia_private_libdir()) -o $sysimage_path $o_file_flags -ljulia-internal -ljulia $extra`
+    cmd = `$(bitflag()) $(march()) -shared -L$(julia_libdir()) -L$(julia_private_libdir()) -o $sysimage_path $o_file_flags $(ldlibs()) $extra`
     run_compiler(cmd; cplusplus=true)
     return nothing
 end

--- a/src/juliaconfig.jl
+++ b/src/juliaconfig.jl
@@ -41,14 +41,14 @@ function ldflags()
 end
 
 function ldlibs()
-    libnames = isdebugbuild() ? `-ljulia-debug -ljulia-internal-debug` : 
-                                `-ljulia       -ljulia-internal`
+    libnames = isdebugbuild() ? "-ljulia-debug -ljulia-internal-debug" : 
+                                "-ljulia       -ljulia-internal"
     if Sys.islinux()
-        return `-Wl,-rpath-link,$(shell_escape(julia_libdir())) -Wl,-rpath-link,$(shell_escape(julia_private_libdir())) $libnames`
+        return "-Wl,-rpath-link,$(shell_escape(julia_libdir())) -Wl,-rpath-link,$(shell_escape(julia_private_libdir())) $libnames"
     elseif Sys.iswindows()
-        return `$libnames -lopenlibm`
+        return "$libnames -lopenlibm"
     else
-        return `$libnames`
+        return "$libnames"
     end
 end
 

--- a/src/juliaconfig.jl
+++ b/src/juliaconfig.jl
@@ -41,14 +41,14 @@ function ldflags()
 end
 
 function ldlibs()
-    libnames = isdebugbuild() ? "-ljulia-debug -ljulia-internal-debug" : 
-                                "-ljulia       -ljulia-internal"
+    libnames = isdebugbuild() ? `-ljulia-debug -ljulia-internal-debug` : 
+                                `-ljulia       -ljulia-internal`
     if Sys.islinux()
-        return "-Wl,-rpath-link,$(shell_escape(julia_libdir())) -Wl,-rpath-link,$(shell_escape(julia_private_libdir())) $libnames"
+        return `-Wl,-rpath-link,$(shell_escape(julia_libdir())) -Wl,-rpath-link,$(shell_escape(julia_private_libdir())) $libnames`
     elseif Sys.iswindows()
-        return "$libnames -lopenlibm"
+        return `$libnames -lopenlibm`
     else
-        return "$libnames"
+        return `$libnames`
     end
 end
 


### PR DESCRIPTION
Julia built with `make debug` does not create `libjulia.so` and `libjulia-internal.so` but `libjulia-debug.so` and `libjulia-internal-debug.so`.