### PR TITLE
Allow the user to pass arbitrary C flags (on all platforms)

### DIFF
--- a/src/PackageCompiler.jl
+++ b/src/PackageCompiler.jl
@@ -118,6 +118,7 @@ const WARNED_CPP_COMPILER = Ref{Bool}(false)
 
 function run_compiler(cmd::Cmd; cplusplus::Bool=false)
     cc = get(ENV, "JULIA_CC", nothing)
+    cc_flags = get(ENV, "JULIA_CC_FLAGS", nothing)
     path = nothing
     @static if Sys.iswindows()
         path = joinpath(LazyArtifacts.artifact"mingw-w64", (Int==Int64 ? "mingw64" : "mingw32"), "bin", cplusplus ? "g++.exe" : "gcc.exe")
@@ -158,7 +159,12 @@ function run_compiler(cmd::Cmd; cplusplus::Bool=false)
     if path !== nothing
         compiler_cmd = addenv(compiler_cmd, "PATH" => string(ENV["PATH"], ";", dirname(path)))
     end
-    full_cmd = `$compiler_cmd $cmd`
+    if cc_flags !== nothing
+        compiler_flags = Cmd(Base.shell_split(cc_flags))
+    else
+        compiler_flags = ``
+    end
+    full_cmd = `$compiler_cmd $compiler_flags $cmd`
     @debug "running $full_cmd"
     run(full_cmd)
 end
@@ -366,7 +372,7 @@ project will be put into the sysimage.
 
 An attempt to automatically find a compiler will be done but can also be given
 explicitly by setting the environment variable `JULIA_CC` to a path to a
-compiler (can also include extra arguments to the compiler, like `-g`).
+compiler. Extra arguments to the compiler (like `-g`) can be specified with `JULIA_CC_FLAGS`.
 
 ### Keyword arguments:
 
@@ -633,7 +639,7 @@ argument, for example:
 
 An attempt to automatically find a compiler will be done but can also be given
 explicitly by setting the environment variable `JULIA_CC` to a path to a
-compiler (can also include extra arguments to the compiler, like `-g`).
+compiler. Extra arguments to the compiler (like `-g`) can be specified with `JULIA_CC_FLAGS`.
 
 ### Keyword arguments:
 
@@ -792,7 +798,7 @@ simply calls `jl_atexit_hook(retcode)`.)
 
 An attempt to automatically find a compiler will be done but can also be given
 explicitly by setting the environment variable `JULIA_CC` to a path to a
-compiler (can also include extra arguments to the compiler, like `-g`).
+compiler. Extra arguments to the compiler (like `-g`) can be specified with `JULIA_CC_FLAGS`.
 
 ### Keyword arguments:
 


### PR DESCRIPTION
Since PC.jl now exposes `c_driver_program` which allows the users to
specify their own C wrapper program, it would be nice to be able to pass
in more variables which might be best defined at build time.

Currently this functionality is effectively limited to Linux as
specifying $JULIA_CC will prevent PC.jl from inferring gcc.exe from
the relative mingw installation.