### PR TITLE
Update minimum tested Julia version to ~1.6.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         julia-version:
-          - '1'
+          - '~1.6.0'
           - '~1.7.0-0'
           # - 'nightly'
         julia-arch:


### PR DESCRIPTION
* Previously, this was set to '1', which (presumably) tested the
  latest stable release.
* We currently promise to support 1.6, so we should always test this,
  even if the latest stable release is bigger