### PR TITLE
`build` and then `precompile` in `ensurecompiled`

### DIFF
--- a/src/PackageCompiler.jl
+++ b/src/PackageCompiler.jl
@@ -219,7 +219,7 @@ end
 function ensurecompiled(project, packages, sysimage)
     length(packages) == 0 && return
     # TODO: Only precompile `packages` (should be available in Pkg 1.8)
-    cmd = `$(get_julia_cmd()) --sysimage=$sysimage -e 'using Pkg; Pkg.precompile()'`
+    cmd = `$(get_julia_cmd()) --sysimage=$sysimage -e 'using Pkg; Pkg.build(); Pkg.precompile()'`
     splitter = Sys.iswindows() ? ';' : ':'
     cmd = addenv(cmd, "JULIA_LOAD_PATH" => "$project$(splitter)@stdlib")
     run(cmd)


### PR DESCRIPTION
- In certain cases like when `Conda` is invloved, the `ensurecompiled` fails if Conda isn't built properly.
