### PR TITLE
check if manifest file exists instead of if manifest empty

### DIFF
--- a/src/PackageCompiler.jl
+++ b/src/PackageCompiler.jl
@@ -63,7 +63,7 @@ function create_pkg_context(project)
         error("could not find project at $(repr(project))")
     end
     ctx = Pkg.Types.Context(env=Pkg.Types.EnvCache(project_toml_path))
-    if isempty(ctx.env.manifest)
+    if isfile(ctx.env.manifest_file)
         @warn "it is not recommended to create an app/library without a preexisting manifest"
     end
     return ctx


### PR DESCRIPTION
Theoretically you could compile a package with an empty manifest