### PR TITLE
Add concurrency control to GitHub workflow runs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,9 @@ on:
       - 'master'
       - 'release-*'
     tags: '*'
+concurrency:
+  group: ${{ github.head_ref || github.ref_name || github.run_id }} 
+  cancel-in-progress: true
 jobs:
   test:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
If this works the way I think it works (and I've tested it a bit on another repo) then this would mean that if one pushes a new commit to a PR or branch that triggers a workflow run, any previous still running instance of the same workflow for that same PR or branch would be cancelled.

Should overall speed things up because one should run less often into resource constraints.