### PR TITLE
Reinstate RelocatableFolders compat & patch bump

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "PackageCompiler"
 uuid = "9b87118b-4619-50d2-8e1e-99f35a4d4d9d"
-version = "2.0.10"
+version = "2.0.11"
 
 [deps]
 Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
@@ -13,7 +13,7 @@ TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [compat]
-RelocatableFolders = "1"
+RelocatableFolders = "0.1, 0.3, 1"
 julia = "1.6"
 
 [extras]


### PR DESCRIPTION
AFAICT RelocatableFolders [v0.3.0 === v1.0.0](https://github.com/JuliaPackaging/RelocatableFolders.jl/compare/v0.3.0...v1.0.0)

and v0.1 was removed in https://github.com/JuliaLang/PackageCompiler.jl/pull/722 but it's not clear that there were test failures on 0.1 