### PR TITLE
Add script kwarg to `create_library` to enable running of custom Julia code

### DIFF
--- a/src/PackageCompiler.jl
+++ b/src/PackageCompiler.jl
@@ -890,7 +890,9 @@ function create_library(package_dir::String,
                         cpu_target::String=default_app_cpu_target(),
                         include_lazy_artifacts::Bool=false,
                         sysimage_build_args::Cmd=``,
-                        include_transitive_dependencies::Bool=true)
+                        include_transitive_dependencies::Bool=true,
+                        script=nothing,
+                        )
 
 
     warn_official()
@@ -926,6 +928,7 @@ function create_library(package_dir::String,
 
     create_sysimage_workaround(ctx, sysimg_path, precompile_execution_file,
         precompile_statements_file, incremental, filter_stdlibs, cpu_target;
+        script=script,
         sysimage_build_args, include_transitive_dependencies, julia_init_c_file, version,
         soname)
 
@@ -989,7 +992,8 @@ function create_sysimage_workaround(
                     include_transitive_dependencies::Bool,
                     julia_init_c_file::Union{Nothing,String},
                     version::Union{Nothing,VersionNumber},
-                    soname::Union{Nothing,String}
+                    soname::Union{Nothing,String},
+                    script=nothing
                     )
     package_name = ctx.env.pkg.name
     project = dirname(ctx.env.project_file)
@@ -1005,6 +1009,7 @@ function create_sysimage_workaround(
 
     create_sysimage([package_name]; sysimage_path, project,
                     incremental=true,
+                    script=script,
                     precompile_execution_file,
                     precompile_statements_file,
                     cpu_target,

--- a/src/PackageCompiler.jl
+++ b/src/PackageCompiler.jl
@@ -893,7 +893,7 @@ function create_library(package_dir::String,
                         include_lazy_artifacts::Bool=false,
                         sysimage_build_args::Cmd=``,
                         include_transitive_dependencies::Bool=true,
-                        script::Union{Nothing,String}=nothing,
+                        script::Union{Nothing,String}=nothing
                         )
 
 
@@ -1010,7 +1010,7 @@ function create_sysimage_workaround(
 
     create_sysimage([package_name]; sysimage_path, project,
                     incremental=true,
-                    script,
+                    script=script,
                     precompile_execution_file,
                     precompile_statements_file,
                     cpu_target,

--- a/src/PackageCompiler.jl
+++ b/src/PackageCompiler.jl
@@ -868,6 +868,8 @@ compiler (can also include extra arguments to the compiler, like `-g`).
   transitive dependencies into the sysimage. This only makes a difference if some
   packages do not load all their dependencies when themselves are loaded. Defaults to `true`.
 
+- `script::String`: Path to a file that gets executed in the `--output-o` process.
+
 ### Advanced keyword arguments
 
 - `cpu_target::String`: The value to use for `JULIA_CPU_TARGET` when building the system image.

--- a/src/PackageCompiler.jl
+++ b/src/PackageCompiler.jl
@@ -891,7 +891,7 @@ function create_library(package_dir::String,
                         include_lazy_artifacts::Bool=false,
                         sysimage_build_args::Cmd=``,
                         include_transitive_dependencies::Bool=true,
-                        script=nothing,
+                        script::Union{Nothing,String}=nothing,
                         )
 
 
@@ -928,9 +928,8 @@ function create_library(package_dir::String,
 
     create_sysimage_workaround(ctx, sysimg_path, precompile_execution_file,
         precompile_statements_file, incremental, filter_stdlibs, cpu_target;
-        script=script,
         sysimage_build_args, include_transitive_dependencies, julia_init_c_file, version,
-        soname)
+        soname, script)
 
     if version !== nothing && Sys.isunix()
         cd(dirname(sysimg_path)) do
@@ -993,7 +992,7 @@ function create_sysimage_workaround(
                     julia_init_c_file::Union{Nothing,String},
                     version::Union{Nothing,VersionNumber},
                     soname::Union{Nothing,String},
-                    script=nothing
+                    script::Union{Nothing,String}
                     )
     package_name = ctx.env.pkg.name
     project = dirname(ctx.env.project_file)
@@ -1009,7 +1008,7 @@ function create_sysimage_workaround(
 
     create_sysimage([package_name]; sysimage_path, project,
                     incremental=true,
-                    script=script,
+                    script,
                     precompile_execution_file,
                     precompile_statements_file,
                     cpu_target,


### PR DESCRIPTION
This PR enables passing optional argument `script` to the function `create_library`. This `script` argument enables the execution of custom user code before compiling a given Julia package into a shared library. This change is not breaking.
