### PR TITLE
Fix 1.9

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ on:
       - 'release-*'
     tags: '*'
 concurrency:
-  group: ${{ github.head_ref || github.ref_name || github.run_id }} 
+  group: ${{ github.head_ref || github.ref_name || github.run_id }}
   cancel-in-progress: true
 jobs:
   test:
@@ -22,6 +22,7 @@ jobs:
           - '1.6'
           - '1.7'
           - '1.8'
+          - '1.9-nightly'
           - 'nightly'
         julia-arch:
           - 'x64'
@@ -30,16 +31,28 @@ jobs:
           - ubuntu-latest
           - macOS-latest
           - windows-latest
+        coverage:
+          - 'true'
+          - 'false' # needed for 1.9+ to test from a session using pkgimages
         exclude:
           - os: macOS-latest
             julia-arch: x86
+          - julia-version: '1.6'
+            coverage: 'false'
+          - julia-version: '1.7'
+            coverage: 'false'
+          - julia-version: '1.8'
+            coverage: 'false'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: julia-actions/setup-julia@latest
         with:
           version: ${{ matrix.julia-version }}
+      - uses: julia-actions/cache@v1
       - uses: julia-actions/julia-runtest@latest
+        with:
+          coverage: ${{ matrix.coverage }}
       - uses: julia-actions/julia-processcoverage@latest
-      - uses: codecov/codecov-action@v1
+      - uses: codecov/codecov-action@v3
         with:
           file: lcov.info

--- a/src/PackageCompiler.jl
+++ b/src/PackageCompiler.jl
@@ -237,7 +237,8 @@ function create_fresh_base_sysimage(stdlibs::Vector{String}; cpu_target::String)
                 cmd = `$(get_julia_cmd()) --cpu-target $cpu_target
                                         --sysimage=$tmp_corecompiler_ji
                                         -g1 -O0 --output-ji=$tmp_sys_ji $new_sysimage_source_path`
-                @debug "running $cmd"
+                @debug "running $cmd" JULIA_CPU_TARGET = cpu_target
+                cmd = addenv(cmd, "JULIA_CPU_TARGET" => cpu_target)
                 read(cmd)
             finally
                 rm(new_sysimage_source_path; force=true)
@@ -384,9 +385,10 @@ function create_sysimg_object_file(object_file::String,
     write(outputo_file, julia_code)
     # Read the input via stdin to avoid hitting the maximum command line limit
 
-    cmd = `$(get_julia_cmd()) --cpu-target=$cpu_target -O3 $sysimage_build_args
+    cmd = `$(get_julia_cmd()) -O3 $sysimage_build_args
                               --sysimage=$base_sysimage --project=$project --output-o=$(object_file) $outputo_file`
-    @debug "running $cmd"
+    @debug "running $cmd" JULIA_CPU_TARGET = cpu_target
+    cmd = addenv(cmd, "JULIA_CPU_TARGET" => cpu_target)
     non = incremental ? "" : "non"
     spinner = TerminalSpinners.Spinner(msg = "PackageCompiler: compiling $(non)incremental system image")
     @monitor_oom TerminalSpinners.@spin spinner run(cmd)

--- a/src/PackageCompiler.jl
+++ b/src/PackageCompiler.jl
@@ -7,7 +7,7 @@ using Printf
 using Artifacts
 using LazyArtifacts
 using UUIDs: UUID, uuid1
-using RelocatableFolders
+JULIAusing RelocatableFolders
 using TOML
 
 export create_sysimage, create_app, create_library
@@ -346,7 +346,6 @@ function create_sysimg_object_file(object_file::String,
     julia_code_buffer = IOBuffer()
     # include all packages into the sysimg
     print(julia_code_buffer, """
-        ENV["JULIA_DEBUG"]="loading"
         Base.reinit_stdio()
         @eval Sys BINDIR = ccall(:jl_get_julia_bindir, Any, ())::String
         @eval Sys STDLIB = $(repr(abspath(Sys.BINDIR, "../share/julia/stdlib", string('v', VERSION.major, '.', VERSION.minor))))

--- a/src/PackageCompiler.jl
+++ b/src/PackageCompiler.jl
@@ -231,6 +231,7 @@ function create_fresh_base_sysimage(stdlibs::Vector{String}; cpu_target::String)
                 cmd = `$(get_julia_cmd()) --cpu-target $cpu_target --output-ji $tmp_corecompiler_ji
                                         -g0 -O0 $compiler_source_path`
                 @debug "running $cmd"
+                cmd
             end
             read(cmd)
 

--- a/src/PackageCompiler.jl
+++ b/src/PackageCompiler.jl
@@ -385,7 +385,7 @@ function create_sysimg_object_file(object_file::String,
     write(outputo_file, julia_code)
     # Read the input via stdin to avoid hitting the maximum command line limit
 
-    cmd = if isdefined(Base, :Loading) # pkgimages feature flag
+    cmd = if isdefined(Base, :Linking) # pkgimages feature flag
         cmd = `$(get_julia_cmd()) -O3 $sysimage_build_args
                                 --sysimage=$base_sysimage --project=$project --output-o=$(object_file) $outputo_file`
         @debug "running $cmd" JULIA_CPU_TARGET = cpu_target

--- a/src/PackageCompiler.jl
+++ b/src/PackageCompiler.jl
@@ -7,7 +7,7 @@ using Printf
 using Artifacts
 using LazyArtifacts
 using UUIDs: UUID, uuid1
-JULIAusing RelocatableFolders
+using RelocatableFolders
 using TOML
 
 export create_sysimage, create_app, create_library

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -77,9 +77,9 @@ end
             finally
             rm(tmp_app_source_dir; recursive=true)
             # Get rid of some local state
-            rm(joinpath(new_depot, "packages"); recursive=true)
-            rm(joinpath(new_depot, "compiled"); recursive=true)
-            rm(joinpath(new_depot, "artifacts"); recursive=true)
+            rm(joinpath(new_depot, "packages"); recursive=true, force=true)
+            rm(joinpath(new_depot, "compiled"); recursive=true, force=true)
+            rm(joinpath(new_depot, "artifacts"); recursive=true, force=true)
             end # try
             app_path(app_name) = abspath(app_compiled_dir, "bin", app_name * (Sys.iswindows() ? ".exe" : ""))
             app_output = read(`$(app_path("MyApp")) I get --args --julia-args --threads=3 --check-bounds=yes -O1`, String)


### PR DESCRIPTION
Closes #755 

#755 was due to the sysimage output process being launched with O2 vs the precompiled O3, so the caches were rejected, entering a state where `__init__` are not run and the RNG wasn't seeded. i.e. the test correctly caught the issue