### PR TITLE
Call `get_compiler_cmd()` at the beginning of `create_sysimage` and `create_app`

### DIFF
--- a/src/PackageCompiler.jl
+++ b/src/PackageCompiler.jl
@@ -483,6 +483,7 @@ function create_sysimage(packages::Union{Nothing, Symbol, Vector{String}, Vector
                          compat_level::String="major",
                          extra_precompiles::String = "",
                          )
+    get_compiler_cmd()
 
     if filter_stdlibs && incremental
         error("must use `incremental=false` to use `filter_stdlibs=true`")
@@ -748,6 +749,7 @@ function create_app(package_dir::String,
                     sysimage_build_args::Cmd=``,
                     include_transitive_dependencies::Bool=true)
     warn_official()
+    get_compiler_cmd()
 
     ctx = create_pkg_context(package_dir)
     ctx.env.pkg === nothing && error("expected package to have a `name`-entry")

--- a/src/PackageCompiler.jl
+++ b/src/PackageCompiler.jl
@@ -483,7 +483,8 @@ function create_sysimage(packages::Union{Nothing, Symbol, Vector{String}, Vector
                          compat_level::String="major",
                          extra_precompiles::String = "",
                          )
-    # We call this at the very beginning to make sure that the user has a compiler available. Therefore, if no compiler is fiund, we throw an error immediately, instead of making the user wait a while before the error is thrown.
+    # We call this at the very beginning to make sure that the user has a compiler available. Therefore, if no compiler 
+    # is found, we throw an error immediately, instead of making the user wait a while before the error is thrown.
     get_compiler_cmd()
 
     if filter_stdlibs && incremental
@@ -750,7 +751,8 @@ function create_app(package_dir::String,
                     sysimage_build_args::Cmd=``,
                     include_transitive_dependencies::Bool=true)
     warn_official()
-    # We call this at the very beginning to make sure that the user has a compiler available. Therefore, if no compiler is fiund, we throw an error immediately, instead of making the user wait a while before the error is thrown.
+    # We call this at the very beginning to make sure that the user has a compiler available. Therefore, if no compiler 
+    # is found, we throw an error immediately, instead of making the user wait a while before the error is thrown.
     get_compiler_cmd()
 
     ctx = create_pkg_context(package_dir)

--- a/src/PackageCompiler.jl
+++ b/src/PackageCompiler.jl
@@ -483,6 +483,7 @@ function create_sysimage(packages::Union{Nothing, Symbol, Vector{String}, Vector
                          compat_level::String="major",
                          extra_precompiles::String = "",
                          )
+    # We call this at the very beginning to make sure that the user has a compiler available. Therefore, if no compiler is fiund, we throw an error immediately, instead of making the user wait a while before the error is thrown.
     get_compiler_cmd()
 
     if filter_stdlibs && incremental
@@ -749,6 +750,7 @@ function create_app(package_dir::String,
                     sysimage_build_args::Cmd=``,
                     include_transitive_dependencies::Bool=true)
     warn_official()
+    # We call this at the very beginning to make sure that the user has a compiler available. Therefore, if no compiler is fiund, we throw an error immediately, instead of making the user wait a while before the error is thrown.
     get_compiler_cmd()
 
     ctx = create_pkg_context(package_dir)


### PR DESCRIPTION
That way, users will immediately get an error if a compiler cannot be found, instead of having to wait a long time before the error is thrown.

Replaces #769
Closes #769 
Closes #677 
Closes #727 