### PR TITLE
clarify that `project` arg should be a path.

### DIFF
--- a/src/PackageCompiler.jl
+++ b/src/PackageCompiler.jl
@@ -59,7 +59,7 @@ end
 
 function create_pkg_context(project)
     if isfile(project)
-        error("project should be specified as path, not as file")
+        error("`project` should be a path to a directory containing a Project/Manifest, not a file")
     end
     project_toml_path = Pkg.Types.projectfile_path(project; strict=true)
     if project_toml_path === nothing

--- a/src/PackageCompiler.jl
+++ b/src/PackageCompiler.jl
@@ -58,6 +58,9 @@ end
 #############
 
 function create_pkg_context(project)
+    if isfile(project)
+        error("project should be specified as path, not as file")
+    end
     project_toml_path = Pkg.Types.projectfile_path(project; strict=true)
     if project_toml_path === nothing
         error("could not find project at $(repr(project))")
@@ -431,7 +434,7 @@ compiler (can also include extra arguments to the compiler, like `-g`).
 
 - `sysimage_path::String`: The path to where the resulting sysimage should be saved.
 
-- `project::String`: The project that should be active when the sysimage is created,
+- `project::String`: The project path that should be active when the sysimage is created,
   defaults to the currently active project.
 
 - `precompile_execution_file::Union{String, Vector{String}}`: A file or list of

--- a/src/PackageCompiler.jl
+++ b/src/PackageCompiler.jl
@@ -434,7 +434,7 @@ compiler (can also include extra arguments to the compiler, like `-g`).
 
 - `sysimage_path::String`: The path to where the resulting sysimage should be saved.
 
-- `project::String`: The project path that should be active when the sysimage is created,
+- `project::String`: The project directory that should be active when the sysimage is created,
   defaults to the currently active project.
 
 - `precompile_execution_file::Union{String, Vector{String}}`: A file or list of


### PR DESCRIPTION
This otherwise yields a confusing error message such as:

```
ERROR: LoadError: could not find project at "/home/user/julia_directory/Project.toml"
```

When this is clearly pointing to a valid julia Project.toml. We will now error and clarify that the path should be specified, not file.