### PR TITLE
CI: add the `ci_started` job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,11 @@ concurrency:
   group: ${{ github.head_ref || github.ref_name || github.run_id }}
   cancel-in-progress: true
 jobs:
+  ci_started:
+    timeout-minutes: 3
+    runs-on: ubuntu-latest
+    steps:
+      - run: exit 0
   test:
     timeout-minutes: 90
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
We will make the `ci_started` status check a required status check. This will prevent us from accidentally merging a PR before any CI jobs have been scheduled or queued.