### PR TITLE
Add excluded_packages keyword argument for create_sysimage

### DIFF
--- a/docs/src/sysimages.md
+++ b/docs/src/sysimages.md
@@ -200,3 +200,6 @@ in your current project.
 - When creating a sysimage incrementally, you can use a different sysimage as the "base sysimage" by passing the `base_sysimage` keyword argument.
 - The "cpu target" can be specified with the `cpu_target` keyword. For more information about the syntax of this option, see the [Julia manual](https://docs.julialang.org/en/v1/devdocs/sysimg/#Specifying-multiple-system-image-targets).
 - If you need to run some code in the process creating the sysimage, the `script` argument that points to a file can be passed.
+- To exclude certain packages in the sysimage, the `excluded_packages` keyword can be used to pass their names. This option can be useful when one want to compile a sysimage for package development where the dependences contains heavy packages with long load times (can be found using `@time_imports using MyDevPackage` in Julia >= 1.8). 
+  In this case, building a system image including the dependencies can significantly reduce the load times of the package in development.  
+  As an example, one can create a system image with `MyDevPackage` included in the `packages` keyword argument with `include_transitive_dependencies=true` to ensure its dependencies are included while excluding `MyDevPackage` itself.

--- a/docs/src/sysimages.md
+++ b/docs/src/sysimages.md
@@ -200,6 +200,6 @@ in your current project.
 - When creating a sysimage incrementally, you can use a different sysimage as the "base sysimage" by passing the `base_sysimage` keyword argument.
 - The "cpu target" can be specified with the `cpu_target` keyword. For more information about the syntax of this option, see the [Julia manual](https://docs.julialang.org/en/v1/devdocs/sysimg/#Specifying-multiple-system-image-targets).
 - If you need to run some code in the process creating the sysimage, the `script` argument that points to a file can be passed.
-- To exclude certain packages in the sysimage, the `excluded_packages` keyword can be used to pass their names. This option can be useful when one want to compile a sysimage for package development where the dependences contains heavy packages with long load times (can be found using `@time_imports using MyDevPackage` in Julia >= 1.8). 
-  In this case, building a system image including the dependencies can significantly reduce the load times of the package in development.  
+- To exclude certain packages in the sysimage, the `excluded_packages` keyword can be used to pass their names. This option can be useful when one want to compile a sysimage for package development where the dependences contain *heavy* packages with long load times (can be found using `@time_imports using MyDevPackage` in Julia >= 1.8). 
+  In this case, building a system image including the dependencies can significantly reduce the load times of the package in development.
   As an example, one can create a system image with `MyDevPackage` included in the `packages` keyword argument with `include_transitive_dependencies=true` to ensure its dependencies are included while excluding `MyDevPackage` itself.

--- a/src/PackageCompiler.jl
+++ b/src/PackageCompiler.jl
@@ -472,6 +472,9 @@ compiler (can also include extra arguments to the compiler, like `-g`).
 
 - `sysimage_build_args::Cmd`: A set of command line options that is used in the Julia process building the sysimage,
   for example `-O1 --check-bounds=yes`.
+
+- `excluded_packages::Union{Vector{String}, Vector{Symbol}}`: Names of the packages to 
+  be excluded in the sysimge.
 """
 function create_sysimage(packages::Union{Nothing, Symbol, Vector{String}, Vector{Symbol}}=nothing;
                          sysimage_path::String,
@@ -483,6 +486,7 @@ function create_sysimage(packages::Union{Nothing, Symbol, Vector{String}, Vector
                          cpu_target::String=NATIVE_CPU_TARGET,
                          script::Union{Nothing, String}=nothing,
                          sysimage_build_args::Cmd=``,
+                         excluded_packages::Union{Vector{String}, Vector{Symbol}}=String[],
                          include_transitive_dependencies::Bool=true,
                          # Internal args
                          base_sysimage::Union{Nothing, String}=nothing,
@@ -510,6 +514,7 @@ function create_sysimage(packages::Union{Nothing, Symbol, Vector{String}, Vector
     end
 
     packages = string.(vcat(packages))
+    excluded_packages = string.(vcat(excluded_packages))
     precompile_execution_file  = vcat(precompile_execution_file)
     precompile_statements_file = vcat(precompile_statements_file)
 
@@ -571,6 +576,10 @@ function create_sysimage(packages::Union{Nothing, Symbol, Vector{String}, Vector
             empty!(new_frontier)
         end
     end
+
+    # Exclude requested packages 
+    packages = filter(x -> !(x in excluded_packages), packages)
+    packages_sysimg = filter(x -> !(x.name in excluded_packages), packages_sysimg)
 
     # Create the sysimage
     object_file = tempname() * ".o"


### PR DESCRIPTION
Added a `excluded_packages` keyword to `create_sysimage` which allows certain packages to be unconditionally excluded in the sysimage. 

Such option can be useful when one want to compile a sysimage for package development where the dependences contain heavy packages with long load times (e.g. found using `@time_imports using MyDevPackage` in Julia >= 1.8). 

In this case, building a system image including the dependencies can significantly reduce the load times of the package in development. 

For example, one may want to create a system image with `MyDevPackage` included in the `packages` keyword argument with `include_transitive_dependencies=true` to ensure its dependencies are included. Then put `MyDevPackage` inside `excluded_packages` so `MyDevPackage` itself is not included in the sysimage (otherwise one cannot develop `MyDevPackage`. 