### PR TITLE
Precompile/import into main flags & warnings for package name conflicts

### DIFF
--- a/src/PackageCompiler.jl
+++ b/src/PackageCompiler.jl
@@ -500,6 +500,9 @@ compiler (can also include extra arguments to the compiler, like `-g`).
 
 - `sysimage_build_args::Cmd`: A set of command line options that is used in the Julia process building the sysimage,
   for example `-O1 --check-bounds=yes`.
+
+- `disable_precompile::Bool`: If `true`, fully disable the precompile stage of the build.
+  Can be helpful in case of package name conflicts in dependencies.
 """
 function create_sysimage(packages::Union{Nothing, Symbol, Vector{String}, Vector{Symbol}}=nothing;
                          sysimage_path::String,


### PR DESCRIPTION
Changelog:
1. added `import_into_main` flag (default true), which allows you to control whether the top level packages will be imported into Main in the sysimage
2. added `disable_precompile` flag (default false), which allows you to turn off the precompile part of the build completely
3. added skip & warnings on the precompile name conflict https://github.com/JuliaLang/PackageCompiler.jl/issues/767
4. added skip & warnings on the import to Main name conflict https://github.com/JuliaLang/PackageCompiler.jl/issues/768

While this doesn't fix the #767 and #768 issues it makes them not error, which in most cases will be fine.
If not then the warning should point the user at some possible solution.
The current solutions to both of these problems are either using the flags added in this PR or modifying the precompile statements.