### PR TITLE
warn early about incorrect `sysimage_path`

### DIFF
--- a/src/PackageCompiler.jl
+++ b/src/PackageCompiler.jl
@@ -504,6 +504,10 @@ function create_sysimage(packages::Union{Nothing, Symbol, Vector{String}, Vector
     # is found, we throw an error immediately, instead of making the user wait a while before the error is thrown.
     get_compiler_cmd()
 
+    if isdir(sysimage_path)
+        error("The provided sysimage_path is a directory: $(sysimage_path). Please specify a full path including the sysimage filename.")
+    end
+
     if filter_stdlibs && incremental
         error("must use `incremental=false` to use `filter_stdlibs=true`")
     end


### PR DESCRIPTION
This possible error happens late in the build, so this change will make it error earlier for the user. Should improve experience a bit.