### PR TITLE
add note about relevence of sysimg in 1.9 era

### DIFF
--- a/docs/src/examples/plots.md
+++ b/docs/src/examples/plots.md
@@ -1,5 +1,15 @@
 # [Creating a sysimage for fast plotting with Plots.jl](@id examples-plots)
 
+!!! note Julia Version 1.9 Performance Update
+    Starting from Julia 1.9, the "time to first plot" (TTFP) has seen a
+    significant improvement due to the introduction of native code
+    caching with Package Images.
+    While the techniques presented in this guide for creating a custom
+    sysimage remain applicable and beneficial for further optimization,
+    please note that the relative improvement will be less dramatic due
+    to the enhanced performance of code loading and execution in recent
+    Julia versions.
+
 A common complaint about Julia is that the "time to first plot" is a bit
 longer than desired. In this example, we will create a sysimage that is made
 to improve this.


### PR DESCRIPTION
I did this benchmark on master (target 1.11), and
got an end-to-end time of 0.8 seconds, so I think
a note is appropriate here for newcomers about
the relevance of sysimgs post-1.9.