### PR TITLE
Avoid name clashes in `PrecompileStagingArea`

### DIFF
--- a/src/PackageCompiler.jl
+++ b/src/PackageCompiler.jl
@@ -423,6 +423,7 @@ function create_sysimg_object_file(object_file::String,
 
     julia_code = String(take!(julia_code_buffer))
     outputo_file = tempname()
+    @debug "writing precompile staging code to $outputo_file"
     write(outputo_file, julia_code)
     # Read the input via stdin to avoid hitting the maximum command line limit
 
@@ -805,7 +806,7 @@ function create_app(package_dir::String,
     # add precompile statements for functions that will be called from the C main() wrapper
     precompiles = String[]
     for (_, julia_main) in executables
-        push!(precompiles, "import $package_name")
+        push!(precompiles, "@isdefined($package_name) || (import $package_name)")
         push!(precompiles, "isdefined($package_name, :$julia_main) && precompile(Tuple{typeof($package_name.$julia_main)})")
     end
     push!(precompiles, "precompile(Tuple{typeof(append!), Vector{String}, Vector{Any}})")


### PR DESCRIPTION
On 1.10 we were running into `cannot declare anonymous.<OurModule> constant; it already has a value` issues as the `extra_precompiles` statement could import a module whose name clashes with an identifier that is already present in the `PrecompileStagingArea`, a la:

```julia
julia> import Dates

julia> mod = Module()
Main.anonymous

julia> @eval mod Dates = $Dates
Dates

julia> @eval mod import Dates
ERROR: cannot declare anonymous.Dates constant; it already has a value
Stacktrace:
 [1] eval(m::Module, e::Any)
   @ Core ./boot.jl:383
 [2] top-level scope
   @ REPL[345]:1
```

The issue is present e.g. in [ubuntu nightly CI](https://github.com/JuliaLang/PackageCompiler.jl/actions/runs/5744338104/job/15570447966):
```
...
LoadError: cannot declare anonymous.MyApp constant; it already has a value
...
```