### PR TITLE
Bundle preferences with apps/libraries

### DIFF
--- a/docs/src/apps.md
+++ b/docs/src/apps.md
@@ -202,6 +202,18 @@ that does some simple arithmetic. It is instructive to see how the [artifact
 file](https://github.com/JuliaLang/PackageCompiler.jl/blob/master/examples/MyApp/Artifacts.toml)
 is [used in the source](https://github.com/JuliaLang/PackageCompiler.jl/blob/d722a3d91abe328ebd239e2f45660be35263ebe1/examples/MyApp/src/MyApp.jl#L7-L8).
 
+### [Preferences](@id app-preferences)
+
+Compile-time preferences used by any of the packages included in the app will be stored in
+the sysimage. To support runtime preferences, all preferences that the app "sees" during the
+compilation process are stored in the app bundle under
+`<app_dir>/share/julia/LocalPreferences.toml`. Note that preferences loaded at compile time
+are *not* affected by the values in the `LocalPreferences.toml`, but modifying the file
+*will* change the value of preferences loaded at runtime.
+
+To learn more about compile time preferences and runtime preferences, please refer to the
+[Preferences.jl docs](https://juliapackaging.github.io/Preferences.jl/stable/).
+
 ### Reverse engineering the compiled app
 
 While the created app is relocatable and no source code is bundled with it,
@@ -281,3 +293,13 @@ CodeInfo(
 │   %10  = Base.repr(%8)
 ...
 ```
+
+#### Preferences in `<app_dir>/share/julia`
+As described [above](@ref app-preferences), a TOML file with all preferences active during
+the compilation process will be stored with the app bundle. If your preferences may contain
+confidential information, you can either delete the
+`<app_dir>/share/julia/LocalPreferences.toml` file before distributing the app bundle, or
+suppress the preference file generation by passing `include_preferences=false` to
+`create_app`. Note, however, that if the preference file is not present, any preference
+loaded in your app at *runtime* will use their default value (or crash, if no default is
+provided).

--- a/docs/src/libs.md
+++ b/docs/src/libs.md
@@ -117,3 +117,15 @@ Note that on Unix-like operating systems (including Mac), your library must have
 
 See [here](https://github.com/simonbyrne/libcg) for a more complete example of how this might look.
 
+### [Preferences](@id library-preferences)
+
+Compile-time preferences used by any of the packages included in the library will be stored in
+the sysimage. To support runtime preferences, all preferences that the library "sees" during the
+compilation process are stored in the library bundle under
+`<dest_dir>/share/julia/LocalPreferences.toml`. Note that preferences loaded at compile time
+are *not* affected by the values in the `LocalPreferences.toml`, but modifying the file
+*will* change the value of preferences loaded at runtime.
+
+To learn more about compile time preferences and runtime preferences, please refer to the
+[Preferences.jl docs](https://juliapackaging.github.io/Preferences.jl/stable/).
+

--- a/src/PackageCompiler.jl
+++ b/src/PackageCompiler.jl
@@ -778,6 +778,9 @@ compiler (can also include extra arguments to the compiler, like `-g`).
   transitive dependencies into the sysimage. This only makes a difference if some
   packages do not load all their dependencies when themselves are loaded. Defaults to `true`.
 
+- `include_preferences::Bool`: If `true`, store all preferences visible by the project in
+  `package_dir` in the app bundle. Defaults to `true`.
+
 ### Advanced keyword arguments
 
 - `cpu_target::String`: The value to use for `JULIA_CPU_TARGET` when building the system image.
@@ -800,6 +803,7 @@ function create_app(package_dir::String,
                     include_lazy_artifacts::Bool=false,
                     sysimage_build_args::Cmd=``,
                     include_transitive_dependencies::Bool=true,
+                    include_preferences::Bool=true,
                     script::Union{Nothing, String}=nothing)
     warn_official()
     if filter_stdlibs && incremental
@@ -822,6 +826,7 @@ function create_app(package_dir::String,
     bundle_julia_libraries(app_dir, stdlibs)
     bundle_julia_executable(app_dir)
     bundle_project(ctx, app_dir)
+    include_preferences && bundle_preferences(ctx, app_dir)
     bundle_cert(app_dir)
 
     sysimage_path = joinpath(app_dir, "lib", "julia", "sys." * Libdl.dlext)
@@ -970,6 +975,9 @@ compiler (can also include extra arguments to the compiler, like `-g`).
   transitive dependencies into the sysimage. This only makes a difference if some
   packages do not load all their dependencies when themselves are loaded. Defaults to `true`.
 
+- `include_preferences::Bool`: If `true`, store all preferences visible by the project in
+  `project_or_package` in the library bundle. Defaults to `true`.
+
 - `script::String`: Path to a file that gets executed in the `--output-o` process.
 
 ### Advanced keyword arguments
@@ -996,6 +1004,7 @@ function create_library(package_or_project::String,
                         include_lazy_artifacts::Bool=false,
                         sysimage_build_args::Cmd=``,
                         include_transitive_dependencies::Bool=true,
+                        include_preferences::Bool=true,
                         script::Union{Nothing,String}=nothing
                         )
 
@@ -1032,6 +1041,7 @@ function create_library(package_or_project::String,
     bundle_artifacts(ctx, dest_dir; include_lazy_artifacts)
     bundle_headers(dest_dir, header_files)
     bundle_project(ctx, dest_dir)
+    include_preferences && bundle_preferences(ctx, dest_dir)
     bundle_cert(dest_dir)
 
     lib_dir = Sys.iswindows() ? joinpath(dest_dir, "bin") : joinpath(dest_dir, "lib")
@@ -1440,6 +1450,43 @@ function bundle_cert(dest_dir)
     share_path = joinpath(dest_dir, "share", "julia")
     mkpath(share_path)
     cp(cert_path, joinpath(share_path, "cert.pem"))
+end
+
+# Write preferences of project `project_dir` to `io`. If `active_project_only`, discard
+# preferences for packages not used in the project in `project_dir`
+function dump_preferences(io::IO, project_dir; active_project_only = true)
+    command = """
+    using TOML, Pkg
+    prefs = Base.get_preferences()
+    if $active_project_only
+        pkgs = map(p -> p.name, values(Pkg.dependencies()))
+        keep = Set(intersect(pkgs, keys(prefs)))
+        filter!(p -> first(p) in keep, prefs)
+    end
+    TOML.print(prefs, sorted=true)
+    """
+    prefs = read(`$(Base.julia_cmd()) --project=$project_dir -e "$command"`, String)
+    write(io, prefs)
+
+    nothing
+end
+function dump_preferences(project_dir; active_project_only = true)
+    dump_preferences(stdout, project_dir; active_project_only)
+end
+
+# Collect all preferences of the active project and store them in the `LOAD_PATH`
+# Note: for apps/libraries, the `LOAD_PATH` defaults to `<dest_dir>/share/julia`
+function bundle_preferences(ctx, dest_dir)
+    share_path = joinpath(dest_dir, "share", "julia")
+    mkpath(share_path)
+    preferences_path = joinpath(share_path, "LocalPreferences.toml")
+    project_dir = dirname(ctx.env.project_file)
+
+    open(preferences_path, "w") do io
+        dump_preferences(io, project_dir)
+    end
+
+    return
 end
 
 end # module


### PR DESCRIPTION
This PR attempts to address those parts of #840 that were not covered by #848. It adds a new function `bundle_preferences` that will create a `LocalPreferences.toml` file with all preferences that can be seen by the package or project for which an app/library is compiled. The preferences will will be included in the app/library bundle under `PREFIX/share/julia` (which is the default `LOAD_PATH`), such that they get picked up automatically.

@staticfloat Do you think that this would adequately address your original issue in #840?