### PR TITLE
Bundle dynamically selected libstdc++

### DIFF
--- a/src/PackageCompiler.jl
+++ b/src/PackageCompiler.jl
@@ -1202,8 +1202,14 @@ function bundle_julia_libraries(dest_dir, stdlibs)
 
     # Bundle the libstdc++ that is actually loaded by Julia
     # xref: https://discourse.julialang.org/t/precedence-of-local-and-julia-shipped-shared-libraries/104258?u=sloede
-    libstdcpp_path = first(filter(contains("libstdc++"), Libdl.dllist()))
-    libstdcpp_dir = dirname(abspath(libstdcpp_path))
+    libstdcpp_search = filter(contains("libstdc++"), Libdl.dllist())
+    if isempty(libstdcpp_search)
+        # Fall back to default search directory if libstdc++ is not loaded
+        libstdcpp_dir = libjulia_dir
+    else
+        # If libstdc++ was found, get absolute path to directory
+        libstdcpp_dir = dirname(abspath(first(libstdcpp_search)))
+    end
 
     # Required libraries
     println("  ├── Base:")

--- a/src/PackageCompiler.jl
+++ b/src/PackageCompiler.jl
@@ -1202,7 +1202,7 @@ function bundle_julia_libraries(dest_dir, stdlibs)
 
     # Bundle the libstdc++ that is actually loaded by Julia
     # xref: https://discourse.julialang.org/t/precedence-of-local-and-julia-shipped-shared-libraries/104258?u=sloede
-    libstdcpp_path = Libdl.dllist() |> filter(contains("libstdc++")) |> first
+    libstdcpp_path = first(filter(contains("libstdc++"), Libdl.dllist()))
     libstdcpp_dir = dirname(abspath(libstdcpp_path))
 
     # Required libraries


### PR DESCRIPTION
Julia by default uses [`libstdcxxprobe()`](https://github.com/JuliaLang/julia/blob/8de80bdf902e0899dd3e39636a95769cf44c823b/cli/loader_lib.c#L254) on Linux systems to figure out whether to load the system `libstdc++` or the one bundled with Julia. Not doing this can cause problems if other libraries used by a Julia process are compiled against a system libstdc++ that is newer than the one provided by Julia

PackageCompiler currently always bundles the library shipped with Julia, not honoring the dynamic selection. This PR aims to remedy this by searching for the `libstdc++` that will be bundled in the directory where the currently loaded `libstdc++` resides.

xref: https://discourse.julialang.org/t/precedence-of-local-and-julia-shipped-shared-libraries/104258?u=sloede

@staticfloat it would be great if you could have a look if this seems like a reasonable implementation to you.

@giordano thanks a lot for the initial pointer on how get the `libstdc++` actually used by Julia.