### PR TITLE
Bump to development version `v2.1.11-pre`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "PackageCompiler"
 uuid = "9b87118b-4619-50d2-8e1e-99f35a4d4d9d"
-version = "2.1.10"
+version = "2.1.11-pre"
 
 [deps]
 Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"


### PR DESCRIPTION
@KristofferC If there are no objections from your side, I'll set the package version in the repo to a `v2.1.11-pre` (for "prerelease").

We have used this successfully in many other packages to make it clear that what's in `master` is in fact not the current release, but the latest development version. Especially when having multiple versions of PackageCompiler.jl in different projects around (dev'd or add'd), it helps to retain at least some sanity...