### PR TITLE
skip testing on 1.8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,6 @@ jobs:
       matrix:
         julia-version:
           - '1.6'
-          - '1.8'
           - '1.9'
           - '1.10-nightly'
           - 'nightly'


### PR DESCRIPTION
This package already takes a very long time testing and testing 1.8 feels excessive since it is neither the LTS nor the latest version.