### PR TITLE
Bump codecov/codecov-action from 3 to 4 + pass CODECOV_TOKEN

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,9 +59,11 @@ jobs:
         with:
           coverage: ${{ matrix.coverage }}
       - uses: julia-actions/julia-processcoverage@latest
-      - uses: codecov/codecov-action@v3
+      - uses: codecov/codecov-action@v4
         with:
           file: lcov.info
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
   docs:
     runs-on: ubuntu-latest
     timeout-minutes: 30


### PR DESCRIPTION
Supersedes #921.

TODO:
- [x] Repo admins: please verify that an appropriate codecov token is set as the repository secret named `CODECOV_TOKEN` before merging.