### PR TITLE
Change naming convention of object files to follow what Base Julia does

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
         os:
           - ubuntu-latest
           - windows-latest
-          # - macos-13 # macos-13 = Intel. # TODO: uncomment this line once we merge #930
+          - macos-13 # macos-13 = Intel.
           # TODO: uncomment the next line, so that we can start testing on macos-14:
           # - macos-14 # macos-14 = Apple Silicon.
         coverage:

--- a/src/PackageCompiler.jl
+++ b/src/PackageCompiler.jl
@@ -226,6 +226,10 @@ function create_fresh_base_sysimage(stdlibs::Vector{String}; cpu_target::String,
     base_dir = dirname(sysimg_source_path)
     tmp_corecompiler_ji = joinpath(tmp, "corecompiler.ji")
     tmp_sys_o = joinpath(tmp, "sys-o.a")
+    # This naming convention (`sys-o.a`) is necessary to make the sysimage
+    # work on macOS.
+    # Bug report: https://github.com/JuliaLang/PackageCompiler.jl/issues/738
+    # PR: https://github.com/JuliaLang/PackageCompiler.jl/pull/930
     tmp_sys_sl = joinpath(tmp, "sys." * Libdl.dlext)
 
     compiler_source_path = joinpath(base_dir, "compiler", "compiler.jl")
@@ -640,6 +644,10 @@ function create_sysimage(packages::Union{Nothing, Symbol, Vector{String}, Vector
 
     # Create the sysimage
     object_file = tempname() * "-o.a"
+    # This naming convention (`-o.a`) is necessary to make the sysimage
+    # work on macOS.
+    # Bug report: https://github.com/JuliaLang/PackageCompiler.jl/issues/738
+    # PR: https://github.com/JuliaLang/PackageCompiler.jl/pull/930
 
     create_sysimg_object_file(object_file, packages, packages_sysimg;
                             project,

--- a/src/PackageCompiler.jl
+++ b/src/PackageCompiler.jl
@@ -225,7 +225,7 @@ function create_fresh_base_sysimage(stdlibs::Vector{String}; cpu_target::String,
     sysimg_source_path = Base.find_source_file("sysimg.jl")
     base_dir = dirname(sysimg_source_path)
     tmp_corecompiler_ji = joinpath(tmp, "corecompiler.ji")
-    tmp_sys_o = joinpath(tmp, "sys.o")
+    tmp_sys_o = joinpath(tmp, "sys-o.a")
     tmp_sys_sl = joinpath(tmp, "sys." * Libdl.dlext)
 
     compiler_source_path = joinpath(base_dir, "compiler", "compiler.jl")
@@ -639,7 +639,7 @@ function create_sysimage(packages::Union{Nothing, Symbol, Vector{String}, Vector
     end
 
     # Create the sysimage
-    object_file = tempname() * ".o"
+    object_file = tempname() * "-o.a"
 
     create_sysimg_object_file(object_file, packages, packages_sysimg;
                             project,
@@ -1428,7 +1428,7 @@ function bundle_julia_libexec(ctx, dest_dir)
     p7zip_exe = basename(p7zip_path)
     cp(p7zip_path, joinpath(bundle_libexec_dir, p7zip_exe))
 
-    return 
+    return
 end
 
 function recursive_dir_size(path)


### PR DESCRIPTION
Fixes #738 

I'm not sure why this makes macos broken, but given that the fix is simple I'm also not going to dig into it. 

The tests don't all pass because `fooifier` isn't there for macos, @staticfloat would need to rebuild it or we just switch to another random artifact. 

It also prints a bunch of
``` 
ld: warning: no platform load command found in '/var/folders/fs/z9fkqy2n5djg4663njw_c20m0000gn/T/jl_4TmZI5eNyL-o.a[2](text#0.o)', assuming: macOS
ld: warning: no platform load command found in '/var/folders/fs/z9fkqy2n5djg4663njw_c20m0000gn/T/jl_4TmZI5eNyL-o.a[3](text#1.o)', assuming: macOS
ld: warning: no platform load command found in '/var/folders/fs/z9fkqy2n5djg4663njw_c20m0000gn/T/jl_4TmZI5eNyL-o.a[4](text#2.o)', assuming: macOS
ld: warning: no platform load command found in '/var/folders/fs/z9fkqy2n5djg4663njw_c20m0000gn/T/jl_4TmZI5eNyL-o.a[5](text#3.o)', assuming: macOS
ld: warning: no platform load command found in '/var/folders/fs/z9fkqy2n5djg4663njw_c20m0000gn/T/jl_4TmZI5eNyL-o.a[6](text#4.o)', assuming: macOS
``` 
Which was fixed by https://github.com/JuliaLang/julia/pull/51830 but that didn't get backported into 1.10.
