### PR TITLE
Make implicit function definition (in `julia_init.c`) an error

### DIFF
--- a/src/juliaconfig.jl
+++ b/src/juliaconfig.jl
@@ -54,7 +54,8 @@ end
 
 function cflags()
     flags = IOBuffer()
-    print(flags, "-O2 -std=gnu99")
+    print(flags, " -Werror-implicit-function-declaration")
+    print(flags, " -O2 -std=gnu99")
     include = shell_escape(julia_includedir())
     print(flags, " -I", include)
     if Sys.isunix()


### PR DESCRIPTION
Someone more familiar with Julia than with C is not likely to recognize the significance of this error, but it's almost always a sign that you've built an object with a broken ABI somewhere.

I've also almost never seen this intentionally ignored in the wild, so I don't expect many false positives.