### PR TITLE
Fix `embedding_wrapper.c` for Julia 1.11; also, run CI on 1.11, but skip the `incremental=false` tests on 1.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
           # - '1.9' # TODO: uncomment this line once we fix the tests on 1.9
           - '1.10' # current LTS
           - '1.11'
-          # - 'nightly' # TODO: decide whether we want to run any CI jobs on nightly.
+          - 'nightly' # TODO: decide whether we want to run any CI jobs on nightly.
         julia-arch:
           - 'x64' # 32-bit Julia
           - 'x86' # 64-bit Julia

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
           - '1.6' # previous LTS
           # - '1.9' # TODO: uncomment this line once we fix the tests on 1.9
           - '1.10' # current LTS
-          # - '1.11' # TODO: uncomment this line once we fix the tests on 1.11
+          - '1.11'
           # - 'nightly' # TODO: decide whether we want to run any CI jobs on nightly.
         julia-arch:
           - 'x64' # 32-bit Julia

--- a/src/embedding_wrapper.c
+++ b/src/embedding_wrapper.c
@@ -105,7 +105,10 @@ int main(int argc, char *argv[]) {
     jl_value_t *firstarg = checked_eval_string("popfirst!(ARGS)");
     JL_GC_PUSH1(&firstarg);
     jl_sym_t *var = jl_symbol("PROGRAM_FILE");
-#if JULIA_VERSION_MAJOR == 1 && JULIA_VERSION_MINOR >= 10
+#if JULIA_VERSION_MAJOR == 1 && JULIA_VERSION_MINOR >= 11
+    jl_binding_t *bp = jl_get_binding_wr(jl_base_module, var, 1);
+    jl_checked_assignment(bp, jl_base_module, var, firstarg);
+#elif JULIA_VERSION_MAJOR == 1 && JULIA_VERSION_MINOR >= 10
     jl_binding_t *bp = jl_get_binding_wr(jl_base_module, var);
     jl_checked_assignment(bp, jl_base_module, var, firstarg);
 #elif JULIA_VERSION_MAJOR == 1 && JULIA_VERSION_MINOR >= 9

--- a/src/embedding_wrapper.c
+++ b/src/embedding_wrapper.c
@@ -106,7 +106,7 @@ int main(int argc, char *argv[]) {
     JL_GC_PUSH1(&firstarg);
     jl_sym_t *var = jl_symbol("PROGRAM_FILE");
 #if JULIA_VERSION_MAJOR == 1 && JULIA_VERSION_MINOR >= 11
-    jl_binding_t *bp = jl_get_binding_wr(jl_base_module, var, 1);
+    jl_binding_t *bp = jl_get_binding_wr(jl_base_module, var, /* alloc */ 1);
     jl_checked_assignment(bp, jl_base_module, var, firstarg);
 #elif JULIA_VERSION_MAJOR == 1 && JULIA_VERSION_MINOR >= 10
     jl_binding_t *bp = jl_get_binding_wr(jl_base_module, var);

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -23,7 +23,7 @@ if is_ci
 end
 
 if is_slow_ci
-    @warn "This is "slow CI" (`is_ci && Sys.ARCH == :aarch64`). Some tests will be skipped or modified." Sys.ARCH
+    @warn "This is \"slow CI\" (`is_ci && Sys.ARCH == :aarch64`). Some tests will be skipped or modified." Sys.ARCH
 end
 
 if is_julia_1_6

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -18,16 +18,20 @@ const is_slow_ci = is_ci && Sys.ARCH == :aarch64
 const is_julia_1_6 = VERSION.major == 1 && VERSION.minor == 6
 const is_julia_1_11 = VERSION.major == 1 && VERSION.minor == 11
 
+if is_ci
+    @show Sys.ARCH
+end
+
+if is_slow_ci
+    @warn "This is "slow CI" (`is_ci && Sys.ARCH == :aarch64`). Some tests will be skipped or modified." Sys.ARCH
+end
+
 if is_julia_1_6
     @warn "This is Julia 1.6. Some tests will be skipped or modified." VERSION
 end
 
 if is_julia_1_11
     @warn "This is Julia 1.11. Some tests will be skipped or modified." VERSION
-end
-
-if is_ci
-    @show Sys.ARCH
 end
 
 function remove_llvmextras(project_file)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -16,7 +16,7 @@ Base.init_depot_path()
 const is_ci = tryparse(Bool, get(ENV, "CI", "")) === true
 const is_slow_ci = is_ci && Sys.ARCH == :aarch64
 const is_julia_1_6 = VERSION.major == 1 && VERSION.minor == 6
-const is_julia_1_6 = VERSION.major == 1 && VERSION.minor == 11
+const is_julia_1_11 = VERSION.major == 1 && VERSION.minor == 11
 
 if is_julia_1_6
     @warn "This is Julia 1.6. Some tests will be skipped or modified." VERSION

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -85,7 +85,7 @@ end
             if is_julia_1_11
                 # On Julia 1.11, `incremental=false` is currently broken: https://github.com/JuliaLang/PackageCompiler.jl/issues/976
                 # So, for now, we skip the `incremental=false` tests on Julia 1.11
-                @warn "This is Julia 1.11; skipping incremental=false test due to known bug: https://github.com/JuliaLang/PackageCompiler.jl/issues/976`
+                @warn "This is Julia 1.11; skipping incremental=false test due to known bug: https://github.com/JuliaLang/PackageCompiler.jl/issues/976"
                 @test_broken false
                 continue
             end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -16,9 +16,14 @@ Base.init_depot_path()
 const is_ci = tryparse(Bool, get(ENV, "CI", "")) === true
 const is_slow_ci = is_ci && Sys.ARCH == :aarch64
 const is_julia_1_6 = VERSION.major == 1 && VERSION.minor == 6
+const is_julia_1_6 = VERSION.major == 1 && VERSION.minor == 11
 
 if is_julia_1_6
     @warn "This is Julia 1.6. Some tests will be skipped or modified." VERSION
+end
+
+if is_julia_1_11
+    @warn "This is Julia 1.11. Some tests will be skipped or modified." VERSION
 end
 
 if is_ci
@@ -73,6 +78,13 @@ end
     app_compiled_dir = joinpath(tmp, "MyAppCompiled")
     @testset for incremental in (is_slow_ci ? (false,) : (true, false))
         if incremental == false
+            if is_julia_1_11
+                # On Julia 1.11, `incremental=false` is currently broken: https://github.com/JuliaLang/PackageCompiler.jl/issues/976
+                # So, for now, we skip the `incremental=false` tests on Julia 1.11
+                @warn "This is Julia 1.11; skipping incremental=false test due to known bug: https://github.com/JuliaLang/PackageCompiler.jl/issues/976`
+                @test_broken false
+                continue
+            end
             filter_stdlibs = (is_slow_ci ? (true, ) : (true, false))
         else
             filter_stdlibs = (false,)


### PR DESCRIPTION
Fixes #951 

This PR does the following:
1. Fix `embedding_wrapper.c`
2. Start running CI on Julia 1.11.

Note: for now, we skip the `incremental=false` tests on Julia 1.11 due to #976.