### PR TITLE
Do not run old Julia versions on ARM, suppress failures with Julia nightly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,8 @@ jobs:
         include:
           - os: macos-13 # Intel
             julia-version: '1.6'
+        allow_failures:
+          - julia_version: nightly
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,13 +42,16 @@ jobs:
           - 'false' # needed for 1.9+ to test from a session using pkgimages
         exclude:
           - os: macOS-latest
-            julia-arch: x86
+            julia-version: '1.6'
           - julia-version: '1.6'
             coverage: 'false'
           - julia-version: '1.7'
             coverage: 'false'
           - julia-version: '1.8'
             coverage: 'false'
+        include:
+          - os: macos-13 # Intel
+            julia-version: '1.6'
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@latest


### PR DESCRIPTION
Get rid of false positives from the continues integration tests for the ARM builds

- [x] do not run the tests for Julia 1.6, 1.7 and 1.8 on ARM, because this is not supported by the build infrastructure
- [x] run the tests on on Julia nightly, but ignore any errors, because they are expected to happen