### PR TITLE
CI: the Julia 1.6 macOS job has to run on `macos-12`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,9 @@
 name: CI
 on:
   pull_request:
-    branches:
-      - 'master'
-      - 'release-*'
+    # branches:
+    #   - 'master'
+    #   - 'release-*'
   push:
     branches:
       - 'master'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,9 +40,14 @@ jobs:
         coverage:
           - 'true'
           - 'false' # needed for 1.9+ to test from a session using pkgimages
+        include:
+          - os: macOS-12
+            julia-version: '1.6'
         exclude:
           - os: macOS-latest
             julia-arch: x86
+          - os: macOS-latest
+            julia-version: '1.6'
           - julia-version: '1.6'
             coverage: 'false'
           - julia-version: '1.7'


### PR DESCRIPTION
Because `macos-latest` now points to `macos-13`, and `macos-13` is Apple Silicon.

Targets `gb/macos-is-odd` (#930).