### PR TITLE
To save CI time, don't test Julia 1.6 on macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,7 +98,7 @@ jobs:
           # If `julia-wordsize` is 64, then we set `arch` to `${{ runner.arch }}`, which
           # GitHub will automatically expand to the correct value (`x86_64` or `aarch64`)
           # based on the architecture of the runner.
-          arch: ${{}}
+          arch: ${{ github.ref == '32' && 'x86' || runner.arch }}
       - uses: julia-actions/cache@824243901fb567ccb490b0d0e2483ccecde46834 # v2.0.5
       - uses: julia-actions/julia-runtest@d0c4f093badade621cd041bba567d1e832480ac2 # v1.10.0
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,16 +68,16 @@ jobs:
         exclude:
           # For now, we'll disable testing 32-bit Julia 1.9 on Windows.
           # TODO: remove the following once we fix the tests for 32-bit Julia 1.9 on Windows.
-          - os: windows-latest
+          - github-runner: windows-latest
             julia-version: '1.9'
             julia-wordsize: '32'
           #
           # We don't have 32-bit builds of Julia for Intel macOS:
-          - os: macos-13 # macos-13 = Intel.
+          - github-runner: macos-13 # macos-13 = Intel.
             julia-wordsize: '32'
           #
           # We don't have 32-bit builds of Julia for Apple Silicon macOS:
-          - os: macos-14 # macos-14 = Apple Silicon.
+          - github-runner: macos-14 # macos-14 = Apple Silicon.
             julia-wordsize: '32'
           #
           # We don't need to run the coverage=false job for Julia < 1.9:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
       - run: exit 0
   test:
     timeout-minutes: 90
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.github-runner }}
     strategy:
       max-parallel: 20 # leave space for other runs in the JuliaLang org, given these tests are long
       fail-fast: false
@@ -51,10 +51,13 @@ jobs:
           - '1.10' # current LTS
           # - '1.11' # TODO: uncomment this line once we fix the tests on 1.11
           # - 'nightly' # TODO: decide whether we want to run any CI jobs on nightly.
-        julia-arch:
-          - 'x64' # 32-bit Julia
-          - 'x86' # 64-bit Julia
-        os:
+        julia-wordsize:
+          # Note: regardless of what value we select here, the underlying GitHub Runner
+          # (virtual machine) will always be a 64-bit operating system. The value here
+          # only affects the version of Julia binary that we download.
+          - '32' # 32-bit Julia. Only available on x86_64. Not available on aarch64.
+          - '64' # 64-bit Julia.
+        github-runner:
           - ubuntu-latest
           - windows-latest
           - macos-13 # macos-13 = Intel.
@@ -66,16 +69,16 @@ jobs:
           # For now, we'll disable testing 32-bit Julia 1.9 on Windows.
           # TODO: remove the following once we fix the tests for 32-bit Julia 1.9 on Windows.
           - os: windows-latest
-            julia-arch: x86
             julia-version: '1.9'
+            julia-wordsize: '32'
           #
-          # We don't have 32-bit builds of Julia for macOS:
-          - os: macos-latest
-            julia-arch: x86
+          # We don't have 32-bit builds of Julia for Intel macOS:
+          - os: macos-13 # macos-13 = Intel.
+            julia-wordsize: '32'
           #
-          # We don't have 32-bit builds of Julia for macOS:
-          - os: macos-latest
-            julia-arch: x86
+          # We don't have 32-bit builds of Julia for Apple Silicon macOS:
+          - os: macos-14 # macos-14 = Apple Silicon.
+            julia-wordsize: '32'
           #
           # We don't need to run the coverage=false job for Julia < 1.9:
           - julia-version: '1.6'
@@ -89,6 +92,13 @@ jobs:
       - uses: julia-actions/setup-julia@9b79636afcfb07ab02c256cede01fe2db6ba808c # v2.6.0
         with:
           version: ${{ matrix.julia-version }}
+          # If `julia-wordsize` is 32, then we set `arch` to `x86`, because we know that
+          # 32-bit builds of Julia are only available for x86.
+          #
+          # If `julia-wordsize` is 64, then we set `arch` to `${{ runner.arch }}`, which
+          # GitHub will automatically expand to the correct value (`x86_64` or `aarch64`)
+          # based on the architecture of the runner.
+          arch: ${{}}
       - uses: julia-actions/cache@824243901fb567ccb490b0d0e2483ccecde46834 # v2.0.5
       - uses: julia-actions/julia-runtest@d0c4f093badade621cd041bba567d1e832480ac2 # v1.10.0
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,12 @@ jobs:
             julia-version: '1.9'
             julia-wordsize: '32'
           #
+          # To save CI time, we don't test Julia 1.6 on macOS.
+          # We still test the LTS (1.10) and 1.11.
+          - github-runner: macos-13 # macos-13 = Intel.
+            julia-version: '1.6'
+          - github-runner: macos-14 # macos-14 = Apple Silicon.
+            julia-version: '1.6'
           # We don't have 32-bit builds of Julia for Intel macOS:
           - github-runner: macos-13 # macos-13 = Intel.
             julia-wordsize: '32'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,8 +58,7 @@ jobs:
           - ubuntu-latest
           - windows-latest
           - macos-13 # macos-13 = Intel.
-          # TODO: uncomment the next line, so that we can start testing on macos-14:
-          # - macos-14 # macos-14 = Apple Silicon.
+          - macos-14 # macos-14 = Apple Silicon.
         coverage:
           - 'true'
           - 'false' # needed for Julia 1.9+ to test from a session using pkgimages


### PR DESCRIPTION
But continue to test the LTS (1.10) and 1.11 on macOS.