### PR TITLE
CI: Test both `incremental={true,false}` on "slow CI"; also, stop considering Apple Silicon macOS as "slow CI"

### DIFF
--- a/.github/workflows/ci.nightly.yml
+++ b/.github/workflows/ci.nightly.yml
@@ -32,8 +32,8 @@ jobs:
           # 2. We intentionally only run one CI job on Julia nightly,
           #    in order to conserve CI resources.
           # 3. This CI only runs on Julia nightly. It doesn't run on
-          #    on Julia pre-releases. For CI on Julia pre-releases,
-          #    see the main CI workflow file.
+          #    Julia pre-releases. For CI on Julia pre-releases, see
+          #    the main CI workflow file.
           - julia-version: 'nightly'
             julia-wordsize: '64'
             github-runner: ubuntu-latest

--- a/.github/workflows/ci.nightly.yml
+++ b/.github/workflows/ci.nightly.yml
@@ -24,8 +24,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # We intentionally only run one CI job on Julia nightly,
-          # in order to conserve CI resources.
+          # 1. We intentionally put nightly CI into a separate YAML
+          #    file (`ci.nightly.yml` versus the main `ci.yml` file).
+          # 2. We intentionally only run one CI job on Julia nightly,
+          #    in order to conserve CI resources.
           - julia-version: 'nightly'
             julia-wordsize: '64'
             github-runner: ubuntu-latest

--- a/.github/workflows/ci.nightly.yml
+++ b/.github/workflows/ci.nightly.yml
@@ -26,8 +26,14 @@ jobs:
         include:
           # 1. We intentionally put nightly CI into a separate YAML
           #    file (`ci.nightly.yml` versus the main `ci.yml` file).
+          #    This allows us to enable and disable the nightly CI
+          #    workflow from the GitHub web UI, without having any
+          #    impact on the main CI.
           # 2. We intentionally only run one CI job on Julia nightly,
           #    in order to conserve CI resources.
+          # 3. This CI only runs on Julia nightly. It doesn't run on
+          #    on Julia pre-releases. For CI on Julia pre-releases,
+          #    see the main CI workflow file.
           - julia-version: 'nightly'
             julia-wordsize: '64'
             github-runner: ubuntu-latest

--- a/.github/workflows/ci.nightly.yml
+++ b/.github/workflows/ci.nightly.yml
@@ -1,0 +1,54 @@
+name: Nightly CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - 'master'
+      - 'release-*'
+    tags: '*'
+  merge_group: # GitHub Merge Queue
+
+concurrency:
+  # Skip intermediate builds: all builds except for builds on the `master` branch
+  # Cancel intermediate builds: only pull request builds
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.ref != 'refs/heads/master' || github.run_number }}
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
+
+jobs:
+  test-nightly:
+    timeout-minutes: 90
+    runs-on: ${{ matrix.github-runner }}
+    strategy:
+      max-parallel: 5 # leave space for other runs in the JuliaLang org, given these tests are long
+      fail-fast: false
+      matrix:
+        include:
+          # We intentionally only run one CI job on Julia nightly,
+          # in order to conserve CI resources.
+          - julia-version: 'nightly'
+            julia-wordsize: '64'
+            github-runner: ubuntu-latest
+            coverage: false
+    steps:
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+      - uses: julia-actions/setup-julia@9b79636afcfb07ab02c256cede01fe2db6ba808c # v2.6.0
+        with:
+          version: ${{ matrix.julia-version }}
+          # If `julia-wordsize` is 32, then we set `arch` to `x86`, because we know that
+          # 32-bit builds of Julia are only available for x86.
+          #
+          # If `julia-wordsize` is 64, then we set `arch` to `${{ runner.arch }}`, which
+          # GitHub will automatically expand to the correct value (`x86_64` or `aarch64`)
+          # based on the architecture of the underlying GitHub Runner (virtual machine).
+          arch: ${{ github.ref == '32' && 'x86' || runner.arch }}
+      - uses: julia-actions/cache@824243901fb567ccb490b0d0e2483ccecde46834 # v2.0.5
+      - uses: julia-actions/julia-runtest@d0c4f093badade621cd041bba567d1e832480ac2 # v1.10.0
+        with:
+          coverage: ${{ matrix.coverage }}
+      - uses: julia-actions/julia-processcoverage@03114f09f119417c3242a9fb6e0b722676aedf38 # v1.2.2
+      - uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
+        with:
+          file: lcov.info
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -14,7 +14,16 @@ ENV["JULIA_DEPOT_PATH"] = new_depot
 Base.init_depot_path()
 
 const is_ci = tryparse(Bool, get(ENV, "CI", "")) === true
-const is_slow_ci = is_ci && Sys.ARCH == :aarch64
+const is_apple_silicon_macos = Sys.ARCH == :aarch64 && Sys.isapple()
+
+# In order to be "slow CI", we must meet all of the following:
+# 1. We are running on CI.
+# 2. We are running on aarch64 (arm64).
+# 3. We are NOT running on Apple Silicon macOS.
+#    (Because for GitHub Actions, the GitHub-hosted Apple Silicon
+#    macOS runners seem to be quite fast.)
+const is_slow_ci = is_ci && Sys.ARCH == :aarch64 && !is_apple_silicon_macos
+
 const is_julia_1_6 = VERSION.major == 1 && VERSION.minor == 6
 const is_julia_1_9 = VERSION.major == 1 && VERSION.minor == 9
 const is_julia_1_11 = VERSION.major == 1 && VERSION.minor == 11

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -18,6 +18,7 @@ const is_slow_ci = is_ci && Sys.ARCH == :aarch64
 const is_julia_1_6 = VERSION.major == 1 && VERSION.minor == 6
 const is_julia_1_9 = VERSION.major == 1 && VERSION.minor == 9
 const is_julia_1_11 = VERSION.major == 1 && VERSION.minor == 11
+const is_julia_1_12 = VERSION.major == 1 && VERSION.minor == 12
 
 if is_ci
     @show Sys.ARCH
@@ -27,7 +28,14 @@ if is_slow_ci
     @warn "This is \"slow CI\" (`is_ci && Sys.ARCH == :aarch64`). Some tests will be skipped or modified." Sys.ARCH
 end
 
-if any([is_julia_1_6, is_julia_1_9, is_julia_1_11])
+const some_tests_skipped = [
+    is_julia_1_6,
+    is_julia_1_9,
+    is_julia_1_11,
+    is_julia_1_12,
+]
+
+if any(some_tests_skipped)
     @warn "This is Julia $(VERSION.major).$(VERSION.minor). Some tests will be skipped or modified." VERSION
 end
 
@@ -79,10 +87,10 @@ end
     app_compiled_dir = joinpath(tmp, "MyAppCompiled")
     @testset for incremental in (is_slow_ci ? (false,) : (true, false))
         if incremental == false
-            if is_julia_1_11
-                # On Julia 1.11, `incremental=false` is currently broken: https://github.com/JuliaLang/PackageCompiler.jl/issues/976
-                # So, for now, we skip the `incremental=false` tests on Julia 1.11
-                @warn "This is Julia 1.11; skipping incremental=false test due to known bug: https://github.com/JuliaLang/PackageCompiler.jl/issues/976"
+            if is_julia_1_11 || is_julia_1_12
+                # On Julia 1.11 and 1.12, `incremental=false` is currently broken: https://github.com/JuliaLang/PackageCompiler.jl/issues/976
+                # So, for now, we skip the `incremental=false` tests on Julia 1.11 and 1.12
+                @warn "This is Julia $(VERSION.major).$(VERSION.minor); skipping incremental=false test due to known bug: https://github.com/JuliaLang/PackageCompiler.jl/issues/976"
                 @test_skip false
                 continue
             end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -85,7 +85,12 @@ end
     # Test creating an app
     app_source_dir = joinpath(@__DIR__, "..", "examples/MyApp/")
     app_compiled_dir = joinpath(tmp, "MyAppCompiled")
-    @testset for incremental in (is_slow_ci ? (false,) : (true, false))
+    if is_slow_ci
+        incrementals_list = (true, false)
+    else
+        incrementals_list = (true, false)
+    end
+    @testset for incremental in incrementals_list
         if incremental == false
             if is_julia_1_11 || is_julia_1_12
                 # On Julia 1.11 and 1.12, `incremental=false` is currently broken.
@@ -96,7 +101,11 @@ end
                 @test_skip false
                 continue
             end
-            filter_stdlibs = (is_slow_ci ? (true, ) : (true, false))
+            if is_slow_ci
+                filter_stdlibs = (true,)
+            else
+                filter_stdlibs = (true, false)
+            end
         else
             filter_stdlibs = (false,)
         end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -197,12 +197,11 @@ end
 
     if !is_slow_ci
         if is_julia_1_12
-        # On Julia 1.12, `incremental=false` is currently broken when doing `create_library()`.
-        # 1.12: No GitHub issue yet.
-        # So, for now, we skip the `incremental=false` tests on Julia 1.12 when doing `create_library()`.
+            # On Julia 1.12, `incremental=false` is currently broken when doing `create_library()`.
+            # 1.12: No GitHub issue yet.
+            # So, for now, we skip the `incremental=false` tests on Julia 1.12 when doing `create_library()`.
             @warn "This is Julia $(VERSION.major).$(VERSION.minor); skipping incremental=false test when doing `create_library()` due to known bug: issue TODO (for 1.12)"
-                @test_skip false
-                continue
+            @test_skip false
         else
             # Test library creation
             lib_source_dir = joinpath(@__DIR__, "..", "examples/MyLib")


### PR DESCRIPTION
In my recent CI experiments, I've discovered some bugs that only occur in one branch of `incremental={true,false}`. So I think we should try to exercise both of those branches in CI, even if we are in "slow CI".