### PR TITLE
Bump version number from `2.1.20` to `2.1.21`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "PackageCompiler"
 uuid = "9b87118b-4619-50d2-8e1e-99f35a4d4d9d"
-version = "2.1.20"
+version = "2.1.21"
 
 [deps]
 Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"


### PR DESCRIPTION
I want to get #984 in for PkgEval purposes. AFAICT, PkgEval only picks up registered versions of packages; IIUC, PkgEval won't pick up `PackageCompiler#master`.

So, for the purposes of PkgEval, in order to get #984 in, we have to register a new release that includes #984.