### PR TITLE
do not put project stdlibs into the base (non-incremental) sysimage

### DIFF
--- a/src/PackageCompiler.jl
+++ b/src/PackageCompiler.jl
@@ -594,7 +594,7 @@ function create_sysimage(packages::Union{Nothing, Symbol, Vector{String}, Vector
         if base_sysimage !== nothing
             error("cannot specify `base_sysimage`  when `incremental=false`")
         end
-        sysimage_stdlibs = filter_stdlibs ? gather_stdlibs_project(ctx) : stdlibs_in_sysimage()
+        sysimage_stdlibs = filter_stdlibs ? String[] : stdlibs_in_sysimage()
         base_sysimage = create_fresh_base_sysimage(sysimage_stdlibs; cpu_target, sysimage_build_args)
     else
         base_sysimage = something(base_sysimage, unsafe_string(Base.JLOptions().image_file))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -231,26 +231,15 @@ end
 
     # Test creating an empty sysimage
     if !is_slow_ci
-        if is_gha_ci && is_julia_1_12
-            # On Julia 1.12, `incremental=false` is currently broken when doing `create_library()`.
-            # 1.12: No GitHub issue yet.
-            # So, for now, we skip the `incremental=false` tests on Julia 1.12 when doing `create_library()`.
-            # But ONLY on GHA (GitHub Actions).
-            # On PkgEval, we do run these tests. This is intentional - we want PkgEval to
-            # detect regressions, as well as fixes for those regressions.
-            @warn "[GHA CI] This is Julia $(VERSION.major).$(VERSION.minor); skipping incremental=false test when doing `create_library()` due to known bug: issue TODO (for 1.12)"
-            @test_skip false
-        else
-            tmp = mktempdir()
-            sysimage_path = joinpath(tmp, "empty." * Libdl.dlext)
-            foreach(x -> touch(joinpath(tmp, x)), ["Project.toml", "Manifest.toml"])
+        tmp = mktempdir()
+        sysimage_path = joinpath(tmp, "empty." * Libdl.dlext)
+        foreach(x -> touch(joinpath(tmp, x)), ["Project.toml", "Manifest.toml"])
 
-            # This is why we need to skip this test on 1.12:
-            incremental=false
+        # This is why we need to skip this test on 1.12:
+        incremental=false
 
-            create_sysimage(String[]; sysimage_path=sysimage_path, incremental=incremental, filter_stdlibs=true, project=tmp)
-            hello = read(`$(Base.julia_cmd()) -J $(sysimage_path) -e 'print("hello, world")'`, String)
-            @test hello == "hello, world"
-        end
+        create_sysimage(String[]; sysimage_path=sysimage_path, incremental=incremental, filter_stdlibs=true, project=tmp)
+        hello = read(`$(Base.julia_cmd()) -J $(sysimage_path) -e 'print("hello, world")'`, String)
+        @test hello == "hello, world"
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -32,8 +32,6 @@ const is_slow_ci = is_ci && Sys.ARCH == :aarch64 && !Sys.isapple()
 
 const is_julia_1_6 = VERSION.major == 1 && VERSION.minor == 6
 const is_julia_1_9 = VERSION.major == 1 && VERSION.minor == 9
-const is_julia_1_11 = VERSION.major == 1 && VERSION.minor == 11
-const is_julia_1_12 = VERSION.major == 1 && VERSION.minor == 12
 
 if is_ci || is_gha_ci
     @info "This is a CI job" Sys.ARCH VERSION is_ci is_gha_ci
@@ -46,8 +44,6 @@ end
 const jlver_some_tests_skipped = [
     is_julia_1_6,
     is_julia_1_9,
-    is_julia_1_11,
-    is_julia_1_12,
 ]
 
 if any(jlver_some_tests_skipped)
@@ -107,18 +103,6 @@ end
     end
     @testset for incremental in incrementals_list
         if incremental == false
-            if is_gha_ci && (is_julia_1_11 || is_julia_1_12)
-                # On Julia 1.11 and 1.12, `incremental=false` is currently broken.
-                # 1.11: https://github.com/JuliaLang/PackageCompiler.jl/issues/976
-                # 1.12: No GitHub issue yet.
-                # So, for now, we skip the `incremental=false` tests on Julia 1.11 and 1.12
-                # But ONLY on GHA (GitHub Actions).
-                # On PkgEval, we do run these tests. This is intentional - we want PkgEval to
-                # detect regressions, as well as fixes for those regressions.
-                @warn "[GHA CI] This is Julia $(VERSION.major).$(VERSION.minor); skipping incremental=false test due to known bug: #976 (for 1.11), issue TODO (for 1.12)"
-                @test_skip false
-                continue
-            end
             if is_slow_ci
                 @warn "Skipping the (incremental=false, filter_stdlibs=false) test because this is \"slow CI\""
                 @test_skip false
@@ -226,34 +210,23 @@ end
     end # testset
 
     if !is_slow_ci
-        if is_gha_ci && is_julia_1_12
-            # On Julia 1.12, `incremental=false` is currently broken when doing `create_library()`.
-            # 1.12: No GitHub issue yet.
-            # So, for now, we skip the `incremental=false` tests on Julia 1.12 when doing `create_library()`.
-            # But ONLY on GHA (GitHub Actions).
-            # On PkgEval, we do run these tests. This is intentional - we want PkgEval to
-            # detect regressions, as well as fixes for those regressions.
-            @warn "[GHA CI] This is Julia $(VERSION.major).$(VERSION.minor); skipping incremental=false test when doing `create_library()` due to known bug: issue TODO (for 1.12)"
-            @test_skip false
-        else
-            # Test library creation
-            lib_source_dir = joinpath(@__DIR__, "..", "examples/MyLib")
-            lib_target_dir = joinpath(tmp, "MyLibCompiled")
+        # Test library creation
+        lib_source_dir = joinpath(@__DIR__, "..", "examples/MyLib")
+        lib_target_dir = joinpath(tmp, "MyLibCompiled")
 
-            # This is why we have to skip this test on 1.12:
-            incremental = false
-            
-            filter = true
-            lib_name = "inc"
+        # This is why we have to skip this test on 1.12:
+        incremental = false
 
-            tmp_lib_src_dir = joinpath(tmp, "MyLib")
-            cp(lib_source_dir, tmp_lib_src_dir)
-            create_library(tmp_lib_src_dir, lib_target_dir; incremental=incremental, force=true, filter_stdlibs=filter,
-                        precompile_execution_file=joinpath(lib_source_dir, "build", "generate_precompile.jl"),
-                        precompile_statements_file=joinpath(lib_source_dir, "build", "additional_precompile.jl"),
-                        lib_name=lib_name, version=v"1.0.0")
-            rm(tmp_lib_src_dir; recursive=true)
-        end
+        filter = true
+        lib_name = "inc"
+
+        tmp_lib_src_dir = joinpath(tmp, "MyLib")
+        cp(lib_source_dir, tmp_lib_src_dir)
+        create_library(tmp_lib_src_dir, lib_target_dir; incremental=incremental, force=true, filter_stdlibs=filter,
+                    precompile_execution_file=joinpath(lib_source_dir, "build", "generate_precompile.jl"),
+                    precompile_statements_file=joinpath(lib_source_dir, "build", "additional_precompile.jl"),
+                    lib_name=lib_name, version=v"1.0.0")
+        rm(tmp_lib_src_dir; recursive=true)
     end
 
     # Test creating an empty sysimage
@@ -274,7 +247,7 @@ end
 
             # This is why we need to skip this test on 1.12:
             incremental=false
-            
+
             create_sysimage(String[]; sysimage_path=sysimage_path, incremental=incremental, filter_stdlibs=true, project=tmp)
             hello = read(`$(Base.julia_cmd()) -J $(sysimage_path) -e 'print("hello, world")'`, String)
             @test hello == "hello, world"


### PR DESCRIPTION
Fixes https://github.com/JuliaLang/PackageCompiler.jl/issues/976

There is no need to do this, the stdlibs used by the project will be included when the final sysimage is built
