### PR TITLE
Bump version number from 2.1.21 to 2.1.22

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "PackageCompiler"
 uuid = "9b87118b-4619-50d2-8e1e-99f35a4d4d9d"
-version = "2.1.21"
+version = "2.1.22"
 
 [deps]
 Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"


### PR DESCRIPTION
In preparation for a new release.

We want to make a new release so that we can get #987 (which fixes #976) into a release.