### PR TITLE
Set `JULIA_PROJECT` when running the subprocess in `ensurecompiled()`

### DIFF
--- a/src/PackageCompiler.jl
+++ b/src/PackageCompiler.jl
@@ -299,8 +299,9 @@ function ensurecompiled(project, packages, sysimage)
     # TODO: Only precompile `packages` (should be available in Pkg 1.8)
     cmd = `$(get_julia_cmd()) --sysimage=$sysimage -e 'using Pkg; Pkg.precompile()'`
     splitter = Sys.iswindows() ? ';' : ':'
-    @debug "ensurecompiled: running $cmd" JULIA_LOAD_PATH = "$project$(splitter)@stdlib"
-    cmd = addenv(cmd, "JULIA_LOAD_PATH" => "$project$(splitter)@stdlib")
+    JULIA_LOAD_PATH = "$project$(splitter)@stdlib"
+    @debug "ensurecompiled: running $cmd" JULIA_LOAD_PATH
+    cmd = addenv(cmd, "JULIA_LOAD_PATH" => JULIA_LOAD_PATH, "JULIA_PROJECT" => project)
     run(cmd)
     return
 end


### PR DESCRIPTION
Suppose that you have two different projects, where one project contains the packages that will go into the sysimage, and the other project is a "build project".

As an example, consider the [`examples/MyLib`](https://github.com/JuliaLang/PackageCompiler.jl/tree/master/examples/MyLib) folder in this repo:
- The `examples/MyLib/Project.toml` is the "main project" that contains the packages that will go into the sysimage.
- The `examples/MyLib/build/Project.toml` is the "build project". The packages in the "build project" will not go into the sysimage. In this example, the "build project" contains `Libdl` and `PackageCompiler`, but neither of those will go into the sysimage.

When the `ensurecompiled()` function is run, we want to make sure that it precompiles the "main project", not the "build project". That's what this PR does.