### PR TITLE
`create_fresh_base_sysimage()`: Pass `""` as the BUILDROOT for Julia 1.12+

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "PackageCompiler"
 uuid = "9b87118b-4619-50d2-8e1e-99f35a4d4d9d"
-version = "2.1.22"
+version = "2.1.23"
 
 [deps]
 Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"

--- a/src/PackageCompiler.jl
+++ b/src/PackageCompiler.jl
@@ -260,10 +260,15 @@ function create_fresh_base_sysimage(stdlibs::Vector{String}; cpu_target::String,
             new_sysimage_source_path = joinpath(tmp, "sysimage_packagecompiler_$(uuid1()).jl")
             write(new_sysimage_source_path, new_sysimage_content)
             try
+                # The final positional argument of "" is to pass BUILDROOT="" to Base.jl.
+                # In Julia 1.11 and earlier, this positional argument will be ignored.
+                # In Julia 1.12 and later, this positional argument will be picked up by Base.jl,
+                # and Base.jl will set Base.BUILDROOT to "".
+                # https://github.com/JuliaLang/PackageCompiler.jl/issues/989
                 cmd = addenv(`$(get_julia_cmd()) --cpu-target $cpu_target
                     --sysimage=$tmp_corecompiler_ji
                     $sysimage_build_args --output-o=$tmp_sys_o
-                    $new_sysimage_source_path`,
+                    $new_sysimage_source_path ""`,
                     "JULIA_LOAD_PATH" => "@stdlib")
                 @debug "running $cmd"
 


### PR DESCRIPTION
Fixes #989.

This fixes the immediate bug in #989, which is that Base.jl incorrectly assumes that our first positional argument is the value of the `BUILDROOT`. The fix is to pass a second positional argument `""`, which is then taken by Base.jl to be the `BUILDROOT`.

This bugfix PR will eventually be followed up by #997, which is a larger PR that will actually take advantage of the new BuildSettings mechanism added to Julia 1.12 in https://github.com/JuliaLang/julia/pull/54387