### PR TITLE
Fix building fresh (non-incremental) sysimages on Julia nightly (Julia 1.12)

### DIFF
--- a/.github/workflows/ci.nightly.yml
+++ b/.github/workflows/ci.nightly.yml
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   test-nightly:
-    timeout-minutes: 90
+    timeout-minutes: 150
     runs-on: ${{ matrix.github-runner }}
     strategy:
       max-parallel: 5 # leave space for other runs in the JuliaLang org, given these tests are long

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
     steps:
       - run: exit 0
   test:
-    timeout-minutes: 90
+    timeout-minutes: 150
     runs-on: ${{ matrix.github-runner }}
     strategy:
       max-parallel: 20 # leave space for other runs in the JuliaLang org, given these tests are long

--- a/src/PackageCompiler.jl
+++ b/src/PackageCompiler.jl
@@ -235,7 +235,9 @@ function create_fresh_base_sysimage(stdlibs::Vector{String}; cpu_target::String,
 
     @static if VERSION >= v"1.12.0-DEV.1617"
         compiler_source_path = joinpath(base_dir, "Base_compiler.jl")
-        compiler_args = `./` # build path
+        buildroot = ""
+        dataroot = relpath(joinpath(Sys.BINDIR, Base.DATAROOTDIR), base_dir) * "/"
+        compiler_args = `--buildroot $buildroot --dataroot $dataroot` # build path
     else
         compiler_source_path = joinpath(base_dir, "compiler", "compiler.jl")
         compiler_args = ``


### PR DESCRIPTION
Fixes #989.

Replaces #996 (closes #996).