### PR TITLE
Increase some CI timeouts

### DIFF
--- a/.github/workflows/ci.nightly.yml
+++ b/.github/workflows/ci.nightly.yml
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   test-nightly:
-    timeout-minutes: 90
+    timeout-minutes: 150
     runs-on: ${{ matrix.github-runner }}
     strategy:
       max-parallel: 5 # leave space for other runs in the JuliaLang org, given these tests are long

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
     steps:
       - run: exit 0
   test:
-    timeout-minutes: 90
+    timeout-minutes: 150
     runs-on: ${{ matrix.github-runner }}
     strategy:
       max-parallel: 20 # leave space for other runs in the JuliaLang org, given these tests are long


### PR DESCRIPTION
Targets `kc/nightly` (#1002).

It looks like nightly CI times have increased, maybe due to the changes in Julia master regarding `Compiler` being moved out.

I suspect that nightly CI will timeout on Kristoffer's PR (#1002).

This PR (which targets #1002) increases some of our timeouts from 1.5 hours (90 minutes) to 2.5 hours (150 minutes).