### PR TITLE
Bump version from 2.1.22 to 2.1.23

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "PackageCompiler"
 uuid = "9b87118b-4619-50d2-8e1e-99f35a4d4d9d"
-version = "2.1.22"
+version = "2.1.23"
 
 [deps]
 Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"


### PR DESCRIPTION
In preparation for a new release.

#1002 was a bugfix, and the only other changes on master are CI changes, so I've bumped the patch.