### PR TITLE
Bump `julia` [compat] to 1.10 (and drop support for 1.6 through 1.9)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,8 +46,6 @@ jobs:
       fail-fast: false
       matrix:
         julia-version:
-          - '1.6' # previous LTS
-          - '1.9'
           - '1.10' # current LTS
           - '1.11' # current stable
           #
@@ -73,20 +71,6 @@ jobs:
           - 'true'
           - 'false' # needed for Julia 1.9+ to test from a session using pkgimages
         exclude:
-          # For now, we'll disable testing 32-bit Julia 1.9 on all operating systems.
-          # TODO: remove the following once we fix the tests for 32-bit Julia 1.9 .
-          - julia-version: '1.9'
-            julia-wordsize: '32'
-          # For now, we'll disable testing 32-bit Julia 1.9 on Windows.
-          # TODO: remove the following once we fix the tests for 32-bit Julia 1.9 on Windows.
-          - github-runner: windows-latest
-            julia-version: '1.9'
-            julia-wordsize: '32'
-          #
-          # Julia 1.6 did not support Apple Silicon:
-          - github-runner: macos-14 # macos-14 = Apple Silicon.
-            julia-version: '1.6'
-          #
           # We don't have 32-bit builds of Julia for Intel macOS:
           - github-runner: macos-13 # macos-13 = Intel.
             julia-wordsize: '32'
@@ -95,13 +79,6 @@ jobs:
           - github-runner: macos-14 # macos-14 = Apple Silicon.
             julia-wordsize: '32'
           #
-          # We don't need to run the coverage=false job for Julia < 1.9:
-          - julia-version: '1.6'
-            coverage: 'false'
-          - julia-version: '1.7'
-            coverage: 'false'
-          - julia-version: '1.8'
-            coverage: 'false'
     steps:
       - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
       - uses: julia-actions/setup-julia@9b79636afcfb07ab02c256cede01fe2db6ba808c # v2.6.0

--- a/Project.toml
+++ b/Project.toml
@@ -24,7 +24,7 @@ Printf = "1"
 RelocatableFolders = "0.1, 0.3, 1"
 TOML = "<0.0.1, 1"
 UUIDs = "<0.0.1, 1"
-julia = "1.6"
+julia = "1.10"
 
 [extras]
 Example = "7876af07-990d-54b4-ab0e-23690620f79a"

--- a/examples/MyApp/src/MyApp.jl
+++ b/examples/MyApp/src/MyApp.jl
@@ -5,13 +5,7 @@ using HelloWorldC_jll
 using Artifacts
 using Distributed
 using Random
-
-# We seem to get problems with LLVMExtra_jll on Julia 1.6 and 1.9
-# Issue for 1.6: https://github.com/JuliaLang/PackageCompiler.jl/issues/706
-# There's no GitHub Issue for 1.9
-@static if (VERSION.major, VERSION.minor) ∉ ((1, 6), (1, 9),)
-    using LLVMExtra_jll
-end
+using LLVMExtra_jll
 
 using micromamba_jll
 
@@ -66,7 +60,7 @@ function real_main()
 
     println("Running the artifact")
     res = readchomp(`$(hello_world_path())`)
-    println("Artifact printed: $res") 
+    println("Artifact printed: $res")
 
     @show unsafe_string(Base.JLOptions().image_file)
     @show Example.domath(5)
@@ -89,12 +83,10 @@ function real_main()
     @eval @everywhere using Example
     @everywhere println(Example.domath(3))
 
-    @static if (VERSION.major, VERSION.minor) ∉ ((1, 6), (1, 9),)
-        if isfile(LLVMExtra_jll.libLLVMExtra_path)
-            println("LLVMExtra path: ok!")
-        else
-            println("LLVMExtra path: fail!")
-        end
+    if isfile(LLVMExtra_jll.libLLVMExtra_path)
+        println("LLVMExtra path: ok!")
+    else
+        println("LLVMExtra path: fail!")
     end
 
     if isfile(micromamba_jll.micromamba_path)

--- a/src/library_selection.jl
+++ b/src/library_selection.jl
@@ -18,8 +18,4 @@ const required_libraries = Dict(
     "mac" =>     ["libLLVM", "libatomic", "libdSFMT", "libgcc_s",     "libgfortran", "libgmp", "libgmpxx", "libgomp", "libjulia-codegen", "libjulia-internal", "libmpfr", "libopenlibm", "libpcre2-8",                                                             "libquadmath", "libssp", "libstdc++", "libuv", "libz"]
 )
 push!(required_libraries["windows"], "libgcc_s_jlj")
-if Sys.VERSION < v"1.7.0"
-    push!(required_libraries["mac"], "libosxunwind")
-else
-    push!(required_libraries["mac"], "libunwind")
-end
+push!(required_libraries["mac"], "libunwind")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -30,24 +30,12 @@ const is_gha_ci = tryparse(Bool, get(ENV, "GITHUB_ACTIONS", "")) === true
 #    macOS runners seem to be quite fast.)
 const is_slow_ci = is_ci && Sys.ARCH == :aarch64 && !Sys.isapple()
 
-const is_julia_1_6 = VERSION.major == 1 && VERSION.minor == 6
-const is_julia_1_9 = VERSION.major == 1 && VERSION.minor == 9
-
 if is_ci || is_gha_ci
     @info "This is a CI job" Sys.ARCH VERSION is_ci is_gha_ci
 end
 
 if is_slow_ci
     @warn "This is \"slow CI\" (defined as any non-macOS CI running on aarch64). Some tests will be skipped or modified." Sys.ARCH
-end
-
-const jlver_some_tests_skipped = [
-    is_julia_1_6,
-    is_julia_1_9,
-]
-
-if any(jlver_some_tests_skipped)
-    @warn "This is Julia $(VERSION.major).$(VERSION.minor). Some tests will be skipped or modified." VERSION
 end
 
 function remove_llvmextras(project_file)
@@ -117,7 +105,7 @@ end
             @info "starting: create_app testset" incremental filter
             tmp_app_source_dir = joinpath(tmp, "MyApp")
             cp(app_source_dir, tmp_app_source_dir)
-            if is_gha_ci && (is_julia_1_6 || is_julia_1_9)
+            if is_gha_ci
                 # Julia 1.6: Issue #706 "Cannot locate artifact 'LLVMExtra'" on 1.6 so remove.
                 # Julia 1.9: There's no GitHub Issue, but it seems we hit a similar problem.
                 @test_skip false
@@ -176,13 +164,8 @@ end
             @test occursin("From worker 4:\t8", app_output)
             @test occursin("From worker 5:\t8", app_output)
 
-            if is_julia_1_6 || is_julia_1_9
-                # Julia 1.6: Issue #706 "Cannot locate artifact 'LLVMExtra'" on 1.6 so remove.
-                # Julia 1.9: There's no GitHub Issue, but it seems we hit a similar problem.
-                @test_skip false
-            else
-                @test occursin("LLVMExtra path: ok!", app_output)
-            end
+
+            @test occursin("LLVMExtra path: ok!", app_output)
             @test occursin("micromamba_jll path: ok!", app_output)
 
             # Test second app


### PR DESCRIPTION
The CI matrix has ballooned up to a ridiculous number of combinations at this point. First step to reduce it seems to be to stop supporting and testing unsupported julia releases. 