### PR TITLE
CI: Always run tests with code coverage enabled (remove the coverage-disabled CI jobs)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,6 @@ jobs:
           - macos-14 # macos-14 = Apple Silicon.
         coverage:
           - 'true'
-          - 'false' # needed for Julia 1.9+ to test from a session using pkgimages
         exclude:
           # For now, we'll disable testing 32-bit Julia 1.9 on all operating systems.
           # TODO: remove the following once we fix the tests for 32-bit Julia 1.9 .


### PR DESCRIPTION
I don't fully understand what this comment means (cc @IanButterworth) but running all tests with and without coverage seems a bit bananas so I'll check what happens if only coverage is used.