### PR TITLE
CI: Reduce number of CI jobs (don't run on Julia 1.9; don't run 32-bit on Julia 1.6)

### DIFF
--- a/.github/workflows/ci.nightly.yml
+++ b/.github/workflows/ci.nightly.yml
@@ -37,7 +37,7 @@ jobs:
           - julia-version: 'nightly'
             julia-wordsize: '64'
             github-runner: ubuntu-latest
-            coverage: false
+            coverage: true
     steps:
       - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
       - uses: julia-actions/setup-julia@9b79636afcfb07ab02c256cede01fe2db6ba808c # v2.6.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,6 @@ jobs:
       matrix:
         julia-version:
           - '1.6' # previous LTS
-          - '1.9'
           - '1.10' # current LTS
           - '1.11' # current stable
           #
@@ -72,16 +71,6 @@ jobs:
         coverage:
           - 'true'
         exclude:
-          # For now, we'll disable testing 32-bit Julia 1.9 on all operating systems.
-          # TODO: remove the following once we fix the tests for 32-bit Julia 1.9 .
-          - julia-version: '1.9'
-            julia-wordsize: '32'
-          # For now, we'll disable testing 32-bit Julia 1.9 on Windows.
-          # TODO: remove the following once we fix the tests for 32-bit Julia 1.9 on Windows.
-          - github-runner: windows-latest
-            julia-version: '1.9'
-            julia-wordsize: '32'
-          #
           # Julia 1.6 did not support Apple Silicon:
           - github-runner: macos-14 # macos-14 = Apple Silicon.
             julia-version: '1.6'
@@ -93,14 +82,6 @@ jobs:
           # We don't have 32-bit builds of Julia for Apple Silicon macOS:
           - github-runner: macos-14 # macos-14 = Apple Silicon.
             julia-wordsize: '32'
-          #
-          # We don't need to run the coverage=false job for Julia < 1.9:
-          - julia-version: '1.6'
-            coverage: 'false'
-          - julia-version: '1.7'
-            coverage: 'false'
-          - julia-version: '1.8'
-            coverage: 'false'
     steps:
       - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
       - uses: julia-actions/setup-julia@9b79636afcfb07ab02c256cede01fe2db6ba808c # v2.6.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,10 @@ jobs:
           - github-runner: macos-14 # macos-14 = Apple Silicon.
             julia-version: '1.6'
           #
+          # To save some CI time, on Julia 1.6 we only run the 64-bit job (and skip the 32-bit job).
+          - julia-version: '1.6'
+            julia-wordsize: '32'
+          #
           # We don't have 32-bit builds of Julia for Intel macOS:
           - github-runner: macos-13 # macos-13 = Intel.
             julia-wordsize: '32'


### PR DESCRIPTION
Alternative to #1005.
Closes #957.

I think this accomplishes the main goal (reduce the number of CI jobs, and thus reduce the total CI time), without needing to change the Julia compat.