### PR TITLE
CI: Don't run the test suite on tags (but do build the docs on tags)

### DIFF
--- a/.github/workflows/ci.nightly.yml
+++ b/.github/workflows/ci.nightly.yml
@@ -17,6 +17,9 @@ concurrency:
 
 jobs:
   test-nightly:
+    # We do not run the full test suite on tags, because we already ran it on master before we made the release.
+    # We do build the docs on tags.
+    if: (github.event_name != 'push') || (github.ref_type == 'tag')
     timeout-minutes: 150
     runs-on: ${{ matrix.github-runner }}
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
   test:
     # We do not run the full test suite on tags, because we already ran it on master before we made the release.
     # We do build the docs on tags.
-    if: (github.event_name != 'push') || (if: github.ref_type == 'tag')
+    if: (github.event_name != 'push') || (github.ref_type == 'tag')
     timeout-minutes: 150
     runs-on: ${{ matrix.github-runner }}
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,9 @@ jobs:
     steps:
       - run: exit 0
   test:
+    # We do not run the full test suite on tags, because we already ran it on master before we made the release.
+    # We do build the docs on tags.
+    if: (github.event_name != 'push') || (if: github.ref_type == 'tag')
     timeout-minutes: 150
     runs-on: ${{ matrix.github-runner }}
     strategy:
@@ -109,6 +112,7 @@ jobs:
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
   docs:
+    # We do build the docs on tags.
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:


### PR DESCRIPTION
There's no need to run the test suite on tags, because before we make a release, we run the test suite on master.

We do need to continue building the docs on tags.