### PR TITLE
Bump version from 2.1.23 to 2.1.24

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "PackageCompiler"
 uuid = "9b87118b-4619-50d2-8e1e-99f35a4d4d9d"
-version = "2.1.23"
+version = "2.1.24"
 
 [deps]
 Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"


### PR DESCRIPTION
In preparation for releasing 2.1.24.

2.1.24 will be the last release of 2.1.x that's cut off the master branch. The next release off the master branch will be 2.2.0, which will drop support for Julia 1.6 through 1.9 (inclusive).