### PR TITLE
Bump version from 2.1.24 to 2.2.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "PackageCompiler"
 uuid = "9b87118b-4619-50d2-8e1e-99f35a4d4d9d"
-version = "2.1.24"
+version = "2.2.0"
 
 [deps]
 Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"


### PR DESCRIPTION
In preparation for a new release.

This new release drops support for Julia 1.6 through 1.9 (inclusive), so we need a minor bump. (We cannot drop Julia support in a patch release.)

There should not be any breaking changes in this release, so a major bump is not required.