### PR TITLE
`embedding_wrapper.c` and `julia_init.c`: Use `JULIA_DEPOT_PATH` and `JULIA_LOAD_PATH` from the environment

### DIFF
--- a/src/embedding_wrapper.c
+++ b/src/embedding_wrapper.c
@@ -37,22 +37,45 @@ jl_value_t *checked_eval_string(const char *code) {
 
 void set_depot_load_path(const char *root_dir) {
 #ifdef _WIN32
+    char *path_sep = ";";
     char *julia_share_subdir = "\\share\\julia";
 #else
+    char *path_sep = ":";
     char *julia_share_subdir = "/share/julia";
 #endif
-    char *share_dir =
-        calloc(sizeof(char), strlen(root_dir) + strlen(julia_share_subdir) + 1);
-    strcat(share_dir, root_dir);
-    strcat(share_dir, julia_share_subdir);
+    int share_path_len = strlen(root_dir) + strlen(julia_share_subdir) + 1;
+
+    char *curr_depot_path = getenv("JULIA_DEPOT_PATH");
+    int curr_depot_path_len = curr_depot_path == NULL ? 0 : strlen(curr_depot_path);
+    int new_depot_path_len = curr_depot_path_len + 1 + share_path_len;
+    char *new_depot_path = calloc(sizeof (char), new_depot_path_len);
+    if (curr_depot_path_len > 0) {
+        strcat(new_depot_path, curr_depot_path);
+        strcat(new_depot_path, path_sep);
+    }
+    strcat(new_depot_path, root_dir);
+    strcat(new_depot_path, julia_share_subdir);
+
+    char *curr_load_path = getenv("JULIA_LOAD_PATH");
+    int curr_load_path_len = curr_load_path == NULL ? 0 : strlen(curr_load_path);
+    int new_load_path_len = curr_load_path_len + 1 + share_path_len;
+    char *new_load_path = calloc(sizeof (char), new_load_path_len);
+    if (curr_load_path_len > 0) {
+        strcat(new_load_path, curr_load_path);
+        strcat(new_load_path, path_sep);
+    }
+    strcat(new_load_path, root_dir);
+    strcat(new_load_path, julia_share_subdir);
 
 #ifdef _WIN32
-    _putenv_s("JULIA_DEPOT_PATH", share_dir);
-    _putenv_s("JULIA_LOAD_PATH", share_dir);
+    _putenv_s("JULIA_DEPOT_PATH", new_depot_path);
+    _putenv_s("JULIA_LOAD_PATH", new_load_path);
 #else
-    setenv("JULIA_DEPOT_PATH", share_dir, 1);
-    setenv("JULIA_LOAD_PATH", share_dir, 1);
+    setenv("JULIA_DEPOT_PATH", new_depot_path, 1);
+    setenv("JULIA_LOAD_PATH", new_load_path, 1);
 #endif
+    free(new_load_path);
+    free(new_depot_path);
 }
 
 // main function (windows UTF16 -> UTF8 argument conversion code copied from

--- a/src/julia_init.c
+++ b/src/julia_init.c
@@ -46,19 +46,39 @@ void set_depot_load_path(const char *root_dir) {
 #else
     char *julia_share_subdir = "/share/julia";
 #endif
-    char *share_dir =
-        calloc(sizeof(char), strlen(root_dir) + strlen(julia_share_subdir) + 1);
-    strcat(share_dir, root_dir);
-    strcat(share_dir, julia_share_subdir);
+    int share_path_len = strlen(root_dir) + strlen(julia_share_subdir) + 1;
+
+    char *curr_depot_path = getenv("JULIA_DEPOT_PATH");
+    int curr_depot_path_len = curr_depot_path == NULL ? 0 : strlen(curr_depot_path);
+    int new_depot_path_len = curr_depot_path_len + 1 + share_path_len;
+    char *new_depot_path = calloc(sizeof (char), new_depot_path_len);
+    if (curr_depot_path_len > 0) {
+        strcat(new_depot_path, curr_depot_path);
+        strcat(new_depot_path, ":");
+    }
+    strcat(new_depot_path, root_dir);
+    strcat(new_depot_path, julia_share_subdir);
+
+    char *curr_load_path = getenv("JULIA_LOAD_PATH");
+    int curr_load_path_len = curr_load_path == NULL ? 0 : strlen(curr_load_path);
+    int new_load_path_len = curr_load_path_len + 1 + share_path_len;
+    char *new_load_path = calloc(sizeof (char), new_load_path_len);
+    if (curr_load_path_len > 0) {
+        strcat(new_load_path, curr_load_path);
+        strcat(new_load_path, ":");
+    }
+    strcat(new_load_path, root_dir);
+    strcat(new_load_path, julia_share_subdir);
 
 #ifdef _WIN32
-    _putenv_s("JULIA_DEPOT_PATH", share_dir);
-    _putenv_s("JULIA_LOAD_PATH", share_dir);
+    _putenv_s("JULIA_DEPOT_PATH", new_depot_path);
+    _putenv_s("JULIA_LOAD_PATH", new_load_path);
 #else
-    setenv("JULIA_DEPOT_PATH", share_dir, 1);
-    setenv("JULIA_LOAD_PATH", share_dir, 1);
+    setenv("JULIA_DEPOT_PATH", new_depot_path, 1);
+    setenv("JULIA_LOAD_PATH", new_load_path, 1);
 #endif
-    free(share_dir);
+    free(new_load_path);
+    free(new_depot_path);
 }
 
 void init_julia(int argc, char **argv) {

--- a/src/julia_init.c
+++ b/src/julia_init.c
@@ -42,8 +42,10 @@ const char *get_sysimage_path(const char *libname) {
 
 void set_depot_load_path(const char *root_dir) {
 #ifdef _WIN32
+    char *path_sep = ";";
     char *julia_share_subdir = "\\share\\julia";
 #else
+    char *path_sep = ":";
     char *julia_share_subdir = "/share/julia";
 #endif
     int share_path_len = strlen(root_dir) + strlen(julia_share_subdir) + 1;
@@ -54,7 +56,7 @@ void set_depot_load_path(const char *root_dir) {
     char *new_depot_path = calloc(sizeof (char), new_depot_path_len);
     if (curr_depot_path_len > 0) {
         strcat(new_depot_path, curr_depot_path);
-        strcat(new_depot_path, ":");
+        strcat(new_depot_path, path_sep);
     }
     strcat(new_depot_path, root_dir);
     strcat(new_depot_path, julia_share_subdir);
@@ -65,7 +67,7 @@ void set_depot_load_path(const char *root_dir) {
     char *new_load_path = calloc(sizeof (char), new_load_path_len);
     if (curr_load_path_len > 0) {
         strcat(new_load_path, curr_load_path);
-        strcat(new_load_path, ":");
+        strcat(new_load_path, path_sep);
     }
     strcat(new_load_path, root_dir);
     strcat(new_load_path, julia_share_subdir);

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -145,8 +145,8 @@ end
             @test occursin("outputo: ok", app_output)
             @test occursin("myrand: ok", app_output)
             # Check env-provided depot and load paths are accepted
-            @test occursin("DEPOT_PATH = [\"$test_depot_path", app_output)
-            @test occursin("LOAD_PATH = [\"$test_load_path", app_output)
+            @test occursin("DEPOT_PATH = [\"$(escape_string(test_depot_path))", app_output)
+            @test occursin("LOAD_PATH = [\"$(escape_string(test_load_path))", app_output)
             # Check distributed
             @test occursin("n = 20000000", app_output)
             @test occursin("From worker 2:\t8", app_output)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -145,8 +145,8 @@ end
             @test occursin("outputo: ok", app_output)
             @test occursin("myrand: ok", app_output)
             # Check env-provided depot and load paths are accepted
-            @test occursin("DEPOT_PATH: [\"$test_depot_path", app_output)
-            @test occursin("LOAD_PATH: [\"$test_load_path", app_output)
+            @test occursin("DEPOT_PATH = [\"$test_depot_path", app_output)
+            @test occursin("LOAD_PATH = [\"$test_load_path", app_output)
             # Check distributed
             @test occursin("n = 20000000", app_output)
             @test occursin("From worker 2:\t8", app_output)


### PR DESCRIPTION
Previously, both the embedding wrapper and `julia_init.c` ignored any existing values set in the environment variables `JULIA_LOAD_PATH` and `JULIA_DEPOT_PATH`; `set_depot_load_path` simply set these up to find libraries as intended by `PackageCompiler.jl`.

However, an app might want to install packages in other locations and have those locations specified via the environment.

This PR modifies `set_depot_load_path` to append `PackageCompiler.jl`'s desired paths to `JULIA_LOAD_PATH` and `JULIA_DEPOT_PATH` rather than overwriting them.

Closes #910.