### PR TITLE
Group all dependabot updates into a single PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,7 @@ updates:
     labels:
       - "dependencies"
       - "github-actions"
+    groups:
+      all-updates:
+        patterns:
+          - "*"


### PR DESCRIPTION
CI takes too long to run for these to all be individual PRs