### PR TITLE
Fix hanging system image creation if multiple threads are set

### DIFF
--- a/src/PackageCompiler.jl
+++ b/src/PackageCompiler.jl
@@ -465,8 +465,8 @@ function create_sysimg_object_file(object_file::String,
     # Make sure, that the final system image is built single-threaded and
     # override any values set by "-t", "--threads" in `sysimage_build_args`
     # or provided via JULIA_NUM_THREADS.
-    # This is needed until the underlying bug is fixed (see #963 and especially
-    # #990 containing a `git bisect` to the commit introducing the problem)
+    # This is needed until the underlying bug is fixed (see https://github.com/JuliaLang/PackageCompiler.jl/issues/963 and especially
+    # https://github.com/JuliaLang/PackageCompiler.jl/issues/990 containing a `git bisect` to the commit introducing the problem)
     cmd = `$(get_julia_cmd()) --cpu-target=$cpu_target $sysimage_build_args
         --sysimage=$base_sysimage --project=$project --output-o=$(object_file)
         --threads=1 $outputo_file`

--- a/src/PackageCompiler.jl
+++ b/src/PackageCompiler.jl
@@ -462,10 +462,15 @@ function create_sysimg_object_file(object_file::String,
     write(outputo_file, julia_code)
     # Read the input via stdin to avoid hitting the maximum command line limit
 
-        cmd = `$(get_julia_cmd()) --cpu-target=$cpu_target $sysimage_build_args
-            --sysimage=$base_sysimage --project=$project --output-o=$(object_file)
-            $outputo_file`
-        @debug "running $cmd"
+    # Make sure, that the final system image is built single-threaded and
+    # override any values set by "-t", "--threads" in `sysimage_build_args`
+    # or provided via JULIA_NUM_THREADS.
+    # This is needed until the underlying bug is fixed (see #963 and especially
+    # #990 containing a `git bisect` to the commit introducing the problem)
+    cmd = `$(get_julia_cmd()) --cpu-target=$cpu_target $sysimage_build_args
+        --sysimage=$base_sysimage --project=$project --output-o=$(object_file)
+        --threads=1 $outputo_file`
+    @debug "running $cmd"
 
     non = incremental ? "" : "non"
     spinner = TerminalSpinners.Spinner(msg = "PackageCompiler: compiling $(non)incremental system image")


### PR DESCRIPTION
Make sure, that the final system image is built single-threaded and override any values set by "-t", "--threads" in sysimage_build_args` or provided via JULIA_NUM_THREADS.
This is needed until the underlying bug is fixed (see #963 and especially #990 containing a `git bisect` to the commit introducing the problem)

References #963 and #990 (but does not fix the underlying bug)

Supersedes #1041 (closes #1041).

Thanks a lot to @KristofferC for the close hit with #1041 limiting down the search area enormously and also to everyone reporting or contributing to the discussions around #963 and #990, especially to @dpinol, @juanromerohb,  @matthewgcooper and last, but certainly not least for a lot of patience with `git bisect`, to @paulmelis.