### PR TITLE
doc: mark URL as such in Markdown

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -58,7 +58,7 @@ Pkg.add("PackageCompiler")
 
 !!! note
     It is strongly recommended to use the official binaries that are downloaded from 
-    https://julialang.org/downloads/. Distribution-provided Julia installations are
+    <https://julialang.org/downloads/>. Distribution-provided Julia installations are
     unlikely to work properly with this package.
  
 To use PackageCompiler a C-compiler needs to be available:


### PR DESCRIPTION
Unlike GitHub flavored Markdown, in "plain" Markdown URLs must be marked as such in order to be turned into links.

Right now it is not, see https://julialang.github.io/PackageCompiler.jl/dev/index.html#Installation-instructions