### PR TITLE
Initialize global `Base.PROGRAM_FILE` correctly

### DIFF
--- a/src/embedding_wrapper.c
+++ b/src/embedding_wrapper.c
@@ -140,25 +140,8 @@ int main(int argc, char *argv[]) {
 
     // Update ARGS and PROGRAM_FILE
     checked_eval_string("append!(empty!(Base.ARGS), Core.ARGS)");
-    jl_value_t *firstarg = checked_eval_string("popfirst!(ARGS)");
-    JL_GC_PUSH1(&firstarg);
-    jl_sym_t *var = jl_symbol("PROGRAM_FILE");
-#if JULIA_VERSION_MAJOR == 1 && JULIA_VERSION_MINOR >= 12
-    jl_binding_t *bp = jl_get_binding_wr(jl_base_module, var);
-    jl_checked_assignment(bp, jl_base_module, var, firstarg);
-#elif JULIA_VERSION_MAJOR == 1 && JULIA_VERSION_MINOR >= 11
-    jl_binding_t *bp = jl_get_binding_wr(jl_base_module, var, /* alloc */ 1);
-    jl_checked_assignment(bp, jl_base_module, var, firstarg);
-#elif JULIA_VERSION_MAJOR == 1 && JULIA_VERSION_MINOR >= 10
-    jl_binding_t *bp = jl_get_binding_wr(jl_base_module, var);
-    jl_checked_assignment(bp, jl_base_module, var, firstarg);
-#elif JULIA_VERSION_MAJOR == 1 && JULIA_VERSION_MINOR >= 9
-    jl_binding_t *bp = jl_get_binding_wr(jl_base_module, var, 1);
-    jl_checked_assignment(bp, firstarg);
-#else
-    jl_set_global(jl_base_module, jl_symbol("PROGRAM_FILE"), firstarg);
-#endif
-    JL_GC_POP();
+    checked_eval_string("Core.eval(Base, :(global PROGRAM_FILE))");
+    checked_eval_string("Base.PROGRAM_FILE = popfirst!(ARGS)");
 
     // call the work function, and get back a value
     jl_value_t *jl_retcode = checked_eval_string(JULIA_MAIN "()");

--- a/src/embedding_wrapper.c
+++ b/src/embedding_wrapper.c
@@ -140,8 +140,28 @@ int main(int argc, char *argv[]) {
 
     // Update ARGS and PROGRAM_FILE
     checked_eval_string("append!(empty!(Base.ARGS), Core.ARGS)");
+
+#if JULIA_VERSION_MAJOR == 1 && JULIA_VERSION_MINOR >= 12
     checked_eval_string("Core.eval(Base, :(global PROGRAM_FILE))");
     checked_eval_string("Base.PROGRAM_FILE = popfirst!(ARGS)");
+#else
+    jl_value_t *firstarg = checked_eval_string("popfirst!(ARGS)");
+    JL_GC_PUSH1(&firstarg);
+    jl_sym_t *var = jl_symbol("PROGRAM_FILE");
+    #if JULIA_VERSION_MAJOR == 1 && JULIA_VERSION_MINOR >= 11
+        jl_binding_t *bp = jl_get_binding_wr(jl_base_module, var, /* alloc */ 1);
+        jl_checked_assignment(bp, jl_base_module, var, firstarg);
+    #elif JULIA_VERSION_MAJOR == 1 && JULIA_VERSION_MINOR >= 10
+        jl_binding_t *bp = jl_get_binding_wr(jl_base_module, var);
+        jl_checked_assignment(bp, jl_base_module, var, firstarg);
+    #elif JULIA_VERSION_MAJOR == 1 && JULIA_VERSION_MINOR >= 9
+        jl_binding_t *bp = jl_get_binding_wr(jl_base_module, var, 1);
+        jl_checked_assignment(bp, firstarg);
+    #else
+        jl_set_global(jl_base_module, jl_symbol("PROGRAM_FILE"), firstarg);
+    #endif
+    JL_GC_POP();
+#endif
 
     // call the work function, and get back a value
     jl_value_t *jl_retcode = checked_eval_string(JULIA_MAIN "()");


### PR DESCRIPTION
Julia 1.12 does not allow setting the global Base.PROGRAM_FILE from another module (probably Main) at program startup with the existing logic.

There probably is a reason why the logic is so complicated. But I currently can't see it. Therefore, just use the already initialized Julia to simply do the work in Julia for all Julia versions instead of hand-crafting solutions which adapt to the evolving C API in different Julia versions.

Fixes #1066