### PR TITLE
Switch CI for stable julia from 1.11 to 1.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
       matrix:
         julia-version:
           - '1.10' # current LTS
-          - '1.11' # current stable
+          - '1.12' # current stable
 
           #
           # 'pre' will install the latest prerelease build (RCs, betas, and alphas).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,7 +128,7 @@ jobs:
       matrix:
         julia-version:
           - '1.10' # current LTS
-          - '1.11' # current stable
+          - '1.12' # current stable
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: julia-actions/setup-julia@5c9647d97b78a5debe5164e9eec09d653d29bd71 # v2.6.1

--- a/examples/MyLib/build/Manifest-v1.10.toml
+++ b/examples/MyLib/build/Manifest-v1.10.toml
@@ -1,183 +1,160 @@
 # This file is machine-generated - editing it directly is not advised
 
-julia_version = "1.12.4"
-manifest_format = "2.0"
-project_hash = "ba1d8bc0db0e286cfa6e0aeca72ed21535741336"
-
-[[deps.ArgTools]]
+[[ArgTools]]
 uuid = "0dad84c5-d112-42e6-8d28-ef12dabb789f"
-version = "1.1.2"
+version = "1.1.1"
 
-[[deps.Artifacts]]
+[[Artifacts]]
 uuid = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
-version = "1.11.0"
 
-[[deps.Base64]]
+[[Base64]]
 uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
-version = "1.11.0"
 
-[[deps.CompilerSupportLibraries_jll]]
-deps = ["Artifacts", "Libdl"]
-uuid = "e66e0078-7015-5450-92f7-15fbd957f2ae"
-version = "1.3.0+1"
-
-[[deps.Dates]]
+[[Dates]]
 deps = ["Printf"]
 uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
-version = "1.11.0"
 
-[[deps.Downloads]]
+[[Downloads]]
 deps = ["ArgTools", "FileWatching", "LibCURL", "NetworkOptions"]
 uuid = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
-version = "1.7.0"
+version = "1.6.0"
 
-[[deps.FileWatching]]
+[[FileWatching]]
 uuid = "7b1f6079-737a-58dc-b8bc-7a2ca5c1b5ee"
-version = "1.11.0"
 
-[[deps.Glob]]
+[[Glob]]
 git-tree-sha1 = "97285bbd5230dd766e9ef6749b80fc617126d496"
 uuid = "c27321d9-0574-5035-807b-f59d2c89b15c"
 version = "1.3.1"
 
-[[deps.JuliaSyntaxHighlighting]]
-deps = ["StyledStrings"]
-uuid = "ac6e5ff7-fb65-4e79-a425-ec3bc9c03011"
-version = "1.12.0"
+[[InteractiveUtils]]
+deps = ["Markdown"]
+uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 
-[[deps.LazyArtifacts]]
+[[LazyArtifacts]]
 deps = ["Artifacts", "Pkg"]
 uuid = "4af54fe1-eca0-43a8-85a7-787d91b784e3"
-version = "1.11.0"
 
-[[deps.LibCURL]]
+[[LibCURL]]
 deps = ["LibCURL_jll", "MozillaCACerts_jll"]
 uuid = "b27032c2-a3e7-50c8-80cd-2d36dbcbfd21"
 version = "0.6.4"
 
-[[deps.LibCURL_jll]]
-deps = ["Artifacts", "LibSSH2_jll", "Libdl", "OpenSSL_jll", "Zlib_jll", "nghttp2_jll"]
+[[LibCURL_jll]]
+deps = ["Artifacts", "LibSSH2_jll", "Libdl", "MbedTLS_jll", "Zlib_jll", "nghttp2_jll"]
 uuid = "deac9b47-8bc7-5906-a0fe-35ac56dc84c0"
-version = "8.15.0+0"
+version = "8.0.1+1"
 
-[[deps.LibGit2]]
-deps = ["LibGit2_jll", "NetworkOptions", "Printf", "SHA"]
+[[LibGit2]]
+deps = ["Base64", "LibGit2_jll", "NetworkOptions", "Printf", "SHA"]
 uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
-version = "1.11.0"
 
-[[deps.LibGit2_jll]]
-deps = ["Artifacts", "LibSSH2_jll", "Libdl", "OpenSSL_jll"]
+[[LibGit2_jll]]
+deps = ["Artifacts", "LibSSH2_jll", "Libdl", "MbedTLS_jll"]
 uuid = "e37daf67-58a4-590a-8e99-b0245dd2ffc5"
-version = "1.9.0+0"
+version = "1.6.4+0"
 
-[[deps.LibSSH2_jll]]
-deps = ["Artifacts", "Libdl", "OpenSSL_jll"]
+[[LibSSH2_jll]]
+deps = ["Artifacts", "Libdl", "MbedTLS_jll"]
 uuid = "29816b5a-b9ab-546f-933c-edad1886dfa8"
-version = "1.11.3+1"
+version = "1.11.0+1"
 
-[[deps.Libdl]]
+[[Libdl]]
 uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
-version = "1.11.0"
 
-[[deps.Logging]]
+[[Logging]]
 uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
-version = "1.11.0"
 
-[[deps.Markdown]]
-deps = ["Base64", "JuliaSyntaxHighlighting", "StyledStrings"]
+[[Markdown]]
+deps = ["Base64"]
 uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
-version = "1.11.0"
 
-[[deps.MozillaCACerts_jll]]
-uuid = "14a3606d-f60d-562e-9121-12d972cd8159"
-version = "2025.11.4"
-
-[[deps.NetworkOptions]]
-uuid = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
-version = "1.3.0"
-
-[[deps.OpenSSL_jll]]
+[[MbedTLS_jll]]
 deps = ["Artifacts", "Libdl"]
-uuid = "458c3c95-2e84-50aa-8efc-19380b2a3a95"
-version = "3.5.4+0"
+uuid = "c8ffd9c3-330d-5841-b78e-0817d7145fa1"
+version = "2.28.2+1"
 
-[[deps.PackageCompiler]]
+[[MozillaCACerts_jll]]
+uuid = "14a3606d-f60d-562e-9121-12d972cd8159"
+version = "2023.1.10"
+
+[[NetworkOptions]]
+uuid = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
+version = "1.2.0"
+
+[[PackageCompiler]]
 deps = ["Artifacts", "Glob", "LazyArtifacts", "Libdl", "Pkg", "Printf", "RelocatableFolders", "TOML", "UUIDs", "p7zip_jll"]
 path = "../../.."
 uuid = "9b87118b-4619-50d2-8e1e-99f35a4d4d9d"
-version = "2.2.4"
+version = "2.1.12"
 
-[[deps.Pkg]]
-deps = ["Artifacts", "Dates", "Downloads", "FileWatching", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "Random", "SHA", "TOML", "Tar", "UUIDs", "p7zip_jll"]
+[[Pkg]]
+deps = ["Artifacts", "Dates", "Downloads", "FileWatching", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "Serialization", "TOML", "Tar", "UUIDs", "p7zip_jll"]
 uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
-version = "1.12.1"
+version = "1.10.0"
 
-    [deps.Pkg.extensions]
-    REPLExt = "REPL"
-
-    [deps.Pkg.weakdeps]
-    REPL = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
-
-[[deps.Printf]]
+[[Printf]]
 deps = ["Unicode"]
 uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
-version = "1.11.0"
 
-[[deps.Random]]
+[[REPL]]
+deps = ["InteractiveUtils", "Markdown", "Sockets", "Unicode"]
+uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
+
+[[Random]]
 deps = ["SHA"]
 uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
-version = "1.11.0"
 
-[[deps.RelocatableFolders]]
+[[RelocatableFolders]]
 deps = ["SHA", "Scratch"]
 git-tree-sha1 = "90bc7a7c96410424509e4263e277e43250c05691"
 uuid = "05181044-ff0b-4ac5-8273-598c1e38db00"
 version = "1.0.0"
 
-[[deps.SHA]]
+[[SHA]]
 uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
 version = "0.7.0"
 
-[[deps.Scratch]]
+[[Scratch]]
 deps = ["Dates"]
 git-tree-sha1 = "f94f779c94e58bf9ea243e77a37e16d9de9126bd"
 uuid = "6c6a2e73-6563-6170-7368-637461726353"
 version = "1.1.1"
 
-[[deps.StyledStrings]]
-uuid = "f489334b-da3d-4c2e-b8f0-e476e12c162b"
-version = "1.11.0"
+[[Serialization]]
+uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
 
-[[deps.TOML]]
+[[Sockets]]
+uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
+
+[[TOML]]
 deps = ["Dates"]
 uuid = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 version = "1.0.3"
 
-[[deps.Tar]]
+[[Tar]]
 deps = ["ArgTools", "SHA"]
 uuid = "a4e569a6-e804-4fa4-b0f3-eef7a1d5b13e"
 version = "1.10.0"
 
-[[deps.UUIDs]]
+[[UUIDs]]
 deps = ["Random", "SHA"]
 uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
-version = "1.11.0"
 
-[[deps.Unicode]]
+[[Unicode]]
 uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
-version = "1.11.0"
 
-[[deps.Zlib_jll]]
+[[Zlib_jll]]
 deps = ["Libdl"]
 uuid = "83775a58-1f1d-513f-b197-d71354ab007a"
-version = "1.3.1+2"
+version = "1.2.13+1"
 
-[[deps.nghttp2_jll]]
+[[nghttp2_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "8e850ede-7688-5339-a07c-302acd2aaf8d"
-version = "1.64.0+1"
+version = "1.52.0+1"
 
-[[deps.p7zip_jll]]
-deps = ["Artifacts", "CompilerSupportLibraries_jll", "Libdl"]
+[[p7zip_jll]]
+deps = ["Artifacts", "Libdl"]
 uuid = "3f19e933-33d8-53b3-aaab-bd5110c3b7a0"
-version = "17.7.0+0"
+version = "17.4.0+2"

--- a/src/PackageCompiler.jl
+++ b/src/PackageCompiler.jl
@@ -150,6 +150,13 @@ function default_sysimage_stdlibs()
             Base.PkgId(Base.UUID("9a3f8284-a2c9-5f02-9a11-845980a1fd5c"), "Random"),
             Base.PkgId(Base.UUID("6462fe0b-24de-5631-8697-dd941f90decc"), "Sockets"),
         ]
+        # In Julia 1.12 MbedTLS_jll is replaced by OpenSSL_jll, and JuliaSyntaxHighlighting is added
+        if VERSION >= v"1.12-"
+            push!(stdlibs, Base.PkgId(Base.UUID("ac6e5ff7-fb65-4e79-a425-ec3bc9c03011"), "JuliaSyntaxHighlighting"))
+            push!(stdlibs, Base.PkgId(Base.UUID("458c3c95-2e84-50aa-8efc-19380b2a3a95"), "OpenSSL_jll"))
+        else
+            push!(stdlibs, Base.PkgId(Base.UUID("c8ffd9c3-330d-5841-b78e-0817d7145fa1"), "MbedTLS_jll"))
+        end
         # Julia 1.13+ adds CompilerSupportLibraries_jll as a transitive dependency of OpenBLAS_jll
         if VERSION >= v"1.13-"
             push!(stdlibs, Base.PkgId(Base.UUID("e66e0078-7015-5450-92f7-15fbd957f2ae"), "CompilerSupportLibraries_jll"))

--- a/src/PackageCompiler.jl
+++ b/src/PackageCompiler.jl
@@ -344,7 +344,7 @@ function create_fresh_base_sysimage(; cpu_target::String, sysimage_build_args::C
             write(new_sysimage_source_path, new_sysimage_content)
             try
                 cmd = addenv(`$(get_julia_cmd()) --cpu-target $cpu_target
-                    --sysimage=$tmp_corecompiler_sl
+                    --sysimage=$tmp_corecompiler_sl --threads=1
                     $sysimage_build_args --output-o=$tmp_sys_o
                     $new_sysimage_source_path $compiler_args`)
                 @debug "running $cmd"

--- a/src/julia_init.c
+++ b/src/julia_init.c
@@ -87,16 +87,31 @@ void init_julia(int argc, char **argv) {
     setup_args(argc, argv);
 
     const char *sysimage_path = get_sysimage_path(JULIAC_PROGRAM_LIBNAME);
-    char *_sysimage_path = strdup(sysimage_path);
+    // Convert to absolute path since jl_init_with_image_file (Julia 1.12+)
+    // resolves relative paths against bindir, which would be incorrect.
+#ifdef _WIN32
+    char *abs_sysimage_path = _fullpath(NULL, sysimage_path, 0);
+#else
+    char *abs_sysimage_path = realpath(sysimage_path, NULL);
+#endif
+    char *_sysimage_path = strdup(abs_sysimage_path);
     char *root_dir = dirname(dirname(_sysimage_path));
     set_depot_load_path(root_dir);
-    free(_sysimage_path);
-    jl_options.image_file = sysimage_path;
 #if JULIA_VERSION_MAJOR == 1 && JULIA_VERSION_MINOR <= 11
+    jl_options.image_file = abs_sysimage_path;
     julia_init(JL_IMAGE_CWD);
 #else
-    jl_init_with_image_file(NULL, sysimage_path);
+    // Julia 1.12+: Pass explicit bindir to avoid incorrect auto-construction on Unix.
+    // When bindir is NULL, Julia constructs it as libdir/../bin (Unix) or libdir (Windows).
+    // PackageCompiler has libdir=root/lib/julia and bindir=root/bin, so on Unix the
+    // auto-constructed path would be root/lib/julia/../bin = root/lib/bin (incorrect).
+    size_t bindir_len = strlen(root_dir) + 5;
+    char *bindir = (char *)malloc(bindir_len);
+    snprintf(bindir, bindir_len, "%s/bin", root_dir);
+    jl_init_with_image_file(bindir, abs_sysimage_path);
+    free(bindir);
 #endif
+    free(_sysimage_path);
 }
 
 void shutdown_julia(int retcode) { jl_atexit_hook(retcode); }

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -138,7 +138,7 @@ end
             # Check julia-args
             @test occursin("(Base.JLOptions()).opt_level = 1", app_output)
             # From Julia 1.12, --threads=3 adds 1 interactive thread
-            expected_threads = VERSION >= v"1.12" ? 4 : 3
+            expected_threads = VERSION >= v"1.12-" ? 4 : 3
             @test occursin("(Base.JLOptions()).nthreads = $expected_threads", app_output)
             @test occursin("(Base.JLOptions()).check_bounds = 1", app_output)
             # Check transitive inclusion of dependencies

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -137,7 +137,9 @@ end
             @test occursin("""ARGS = ["I", "get", "--args", "áéíóú"]""", app_output)
             # Check julia-args
             @test occursin("(Base.JLOptions()).opt_level = 1", app_output)
-            @test occursin("(Base.JLOptions()).nthreads = 3", app_output)
+            # From Julia 1.12, --threads=3 adds 1 interactive thread
+            expected_threads = VERSION >= v"1.12" ? 4 : 3
+            @test occursin("(Base.JLOptions()).nthreads = $expected_threads", app_output)
             @test occursin("(Base.JLOptions()).check_bounds = 1", app_output)
             # Check transitive inclusion of dependencies
             @test occursin("is_crayons_loaded() = true", app_output)


### PR DESCRIPTION
Some changes for 1.12 have already been merged, see https://github.com/JuliaLang/PackageCompiler.jl/pull/1047 and https://github.com/JuliaLang/PackageCompiler.jl/pull/1068.

This contains several test and code fixes to get the tests to pass on Julia 1.12.4.

https://github.com/JuliaLang/PackageCompiler.jl/pull/1078/changes/36460939271a473c51ed6b68745298b3b84291e7 fixes https://github.com/JuliaLang/PackageCompiler.jl/issues/1084