### PR TITLE
Widen copy_globs to accept any Glob.glob pattern type

### DIFF
--- a/src/PackageCompiler.jl
+++ b/src/PackageCompiler.jl
@@ -1021,9 +1021,12 @@ runtime behavior.
 - `include_transitive_dependencies::Bool=true`: If `true`, include transitive dependencies in the sysimage.
 - `include_preferences::Bool=true`: Bundle package preferences into `share/julia/LocalPreferences.toml`.
 - `script::Union{Nothing,String}=nothing`: Optional script executed while generating the sysimage.
-- `copy_globs::Vector{String}=String[]`: Glob patterns for copying package files to the stdlib directory.
+- `copy_globs::Vector=[]`: Patterns for copying package files to the stdlib directory.
+  Each element can be anything [`Glob.glob`](https://github.com/vtjnash/Glob.jl) accepts as a pattern:
+  a `String`, a `GlobMatch`, or a `Vector` of matchers (strings, `Regex`, `Glob.FilenameMatch`, etc.).
   Patterns are relative to each package root and apply to all packages in the distribution.
   Example: `["assets/**", "data/**"]` copies assets and data directories for all packages.
+  For case-insensitive matching, use `Glob.FilenameMatch` patterns: `[[fn"license*"i]]`.
 """
 function create_distribution(project_dir::String,
                              dist_dir::String;
@@ -1037,7 +1040,7 @@ function create_distribution(project_dir::String,
                              include_transitive_dependencies::Bool=true,
                              include_preferences::Bool=true,
                              script::Union{Nothing, String}=nothing,
-                             copy_globs::Vector{String}=String[],
+                             copy_globs::Vector=[],
                              release_banner::Union{Nothing, String}=nothing)
     ctx = create_pkg_context(project_dir)
     Pkg.instantiate(ctx, verbose=true, allow_autoprecomp=false)
@@ -1572,7 +1575,7 @@ function bundle_default_stdlibs(dest_dir)
 end
 
 function bundle_custom_stdlibs(ctx, dest_dir, packages::Vector{Pkg.Types.PackageEntry},
-                               copy_globs::Vector{String}=String[])
+                               copy_globs::Vector=[])
     isempty(packages) && return
     version_dir = joinpath(dest_dir, "share", "julia", "stdlib", string('v', VERSION.major, '.', VERSION.minor))
     mkpath(version_dir)
@@ -1593,8 +1596,8 @@ function bundle_custom_stdlibs(ctx, dest_dir, packages::Vector{Pkg.Types.Package
         # Copy files matching glob patterns if specified
         if !isempty(copy_globs)
             for pattern in copy_globs
-                # For patterns ending with ** or **/*, copy entire directory tree recursively
-                if endswith(pattern, "**") || endswith(pattern, "**/*")
+                # For string patterns ending with ** or **/*, copy entire directory tree recursively
+                if pattern isa AbstractString && (endswith(pattern, "**") || endswith(pattern, "**/*"))
                     base_dir = replace(replace(pattern, "**/*" => ""), "**" => "")
                     base_dir = rstrip(base_dir, ['/', '\\'])
                     source_dir = joinpath(pkg_source_path, base_dir)
@@ -1614,7 +1617,7 @@ function bundle_custom_stdlibs(ctx, dest_dir, packages::Vector{Pkg.Types.Package
                         end
                     end
                 else
-                    # Use glob for specific patterns
+                    # Use glob for specific patterns (accepts String, GlobMatch, Vector of matchers, etc.)
                     matched_files = glob(pattern, pkg_source_path)
                     for src_file in matched_files
                         if isfile(src_file)


### PR DESCRIPTION
## Summary
- Widens `copy_globs` from `Vector{String}` to `Vector` so each element can be anything `Glob.glob` accepts: a `String`, `GlobMatch`, or `Vector` of matchers (including `Regex`, `Glob.FilenameMatch`, etc.)
- Enables case-insensitive matching via e.g. `copy_globs=[[fn"license*"i]]`
- Adds `isa AbstractString` guard on the `**` special-case so non-string patterns fall through to `glob()` directly

Addresses [review feedback from @bauglir](https://github.com/JuliaLang/PackageCompiler.jl/pull/1073#discussion_r2774260236).

## Test plan
- [x] Verified module loads and precompiles cleanly
- [x] Verified `Vector{String}` still works (backward compatible)
- [x] Verified `GlobMatch`, `FilenameMatch`, and mixed vectors are accepted
- [x] Verified `isa AbstractString` guard correctly dispatches string vs non-string patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)