### PR TITLE
Avoid error on rebuild with JuliaC

### DIFF
--- a/src/PackageCompiler.jl
+++ b/src/PackageCompiler.jl
@@ -1684,7 +1684,7 @@ function bundle_cert(dest_dir)
     cert_path = joinpath(Sys.BINDIR, "..", "share", "julia", "cert.pem")
     share_path = joinpath(dest_dir, "share", "julia")
     mkpath(share_path)
-    cp(cert_path, joinpath(share_path, "cert.pem"))
+    cp(cert_path, joinpath(share_path, "cert.pem"), force=true)
 end
 
 # Write preferences for packages in project `project_dir` to `io`

--- a/src/PackageCompiler.jl
+++ b/src/PackageCompiler.jl
@@ -1776,7 +1776,7 @@ function bundle_cert(dest_dir)
     cert_path = joinpath(Sys.BINDIR, "..", "share", "julia", "cert.pem")
     share_path = joinpath(dest_dir, "share", "julia")
     mkpath(share_path)
-    cp(cert_path, joinpath(share_path, "cert.pem"))
+    cp(cert_path, joinpath(share_path, "cert.pem"), force=true)
 end
 
 # Write preferences for packages in project `project_dir` to `io`


### PR DESCRIPTION
Force copy of cert.pem in bundle_cert function.

Setting `force=true` avoids aborting JuliaC with an error when building a second time. It should be save to overwrite the cert file, as it has been copied by PackageCompiler.jl and the user requested to regenerate the app.