### PR TITLE
Windows: Do not `-Wl,--export-all-symbols` by default

### DIFF
--- a/src/PackageCompiler.jl
+++ b/src/PackageCompiler.jl
@@ -806,7 +806,7 @@ function get_extra_linker_flags(version, compat_level, soname)
     soname_arg = soname === nothing ? `` : `-Wl,-soname,$soname`
     rpath_args = rpath_sysimage()
 
-    extra = Sys.iswindows() ? `-Wl,--export-all-symbols` :
+    extra = Sys.iswindows() ? (VERSION >= v"1.11" ? `-Wl,--export-all-symbols` : ``) :
             Sys.isapple() ? `-fPIC $compat_ver_arg $current_ver_arg $rpath_args` :
             Sys.isunix() ? `-fPIC $soname_arg $rpath_args` :
                 error("unknown machine type, not windows, macOS not UNIX")

--- a/src/julia_init.c
+++ b/src/julia_init.c
@@ -8,17 +8,24 @@ JL_DLLEXPORT char *dirname(char *);
 #include <libgen.h>
 #endif
 
+#ifdef _OS_WINDOWS_
+#define DLLEXPORT __declspec(dllexport)
+#else
+#define DLLEXPORT
+#endif
+
+
 // Julia headers (for initialization and gc commands)
 #include "julia.h"
 #include "julia_init.h"
 #include "uv.h"
 
-void setup_args(int argc, char **argv) {
+static void setup_args(int argc, char **argv) {
     uv_setup_args(argc, argv);
     jl_parse_opts(&argc, &argv);
 }
 
-const char *get_sysimage_path(const char *libname) {
+static const char *get_sysimage_path(const char *libname) {
     if (libname == NULL) {
         jl_error("julia: Specify `libname` when requesting the sysimage path");
         exit(1);
@@ -40,7 +47,7 @@ const char *get_sysimage_path(const char *libname) {
     return libpath;
 }
 
-void set_depot_load_path(const char *root_dir) {
+static void set_depot_load_path(const char *root_dir) {
 #ifdef _WIN32
     char *path_sep = ";";
     char *julia_share_subdir = "\\share\\julia";
@@ -83,7 +90,7 @@ void set_depot_load_path(const char *root_dir) {
     free(new_depot_path);
 }
 
-void init_julia(int argc, char **argv) {
+DLLEXPORT void init_julia(int argc, char **argv) {
     setup_args(argc, argv);
 
     const char *sysimage_path = get_sysimage_path(JULIAC_PROGRAM_LIBNAME);
@@ -114,4 +121,4 @@ void init_julia(int argc, char **argv) {
     free(_sysimage_path);
 }
 
-void shutdown_julia(int retcode) { jl_atexit_hook(retcode); }
+DLLEXPORT void shutdown_julia(int retcode) { jl_atexit_hook(retcode); }

--- a/src/juliaconfig.jl
+++ b/src/juliaconfig.jl
@@ -40,7 +40,18 @@ function ldflags()
     fl = "-L$(shell_escape(julia_libdir())) -L$(shell_escape(julia_private_libdir()))"
     if Sys.iswindows()
         fl = fl * " -Wl,--stack,8388608"
-        fl = fl * " -Wl,--export-all-symbols"
+        if VERSION >= v"1.11"
+            # This should not really be necessary if users are using DLLEXPORT as required
+            # on Windows in any compiled / init `.c` files, but we keep these flag for
+            # backwards-compatibility on v1.11+ where it is mostly harmless now that LLVM
+            # 16+ emits `-exclude-symbols` directives
+            #
+            # On Julia 1.10, users must annotate their code with DLLEXPORT for it to link,
+            # since this flag would cause Julia to easily hit COFF symbol limits.
+            #
+            # (see https://github.com/JuliaLang/julia/pull/59736)
+            fl = fl * " -Wl,--export-all-symbols"
+        end
     elseif Sys.islinux()
         fl = fl * " -Wl,--export-dynamic"
     end


### PR DESCRIPTION
I have been hitting:
```
ld.exe: error: export ordinal too large: 112510
```
in CI for an external project.

This appears to be a failure of https://github.com/JuliaLang/julia/commit/eb4416b16b8a865376da5c76451a4d60516e2c4a. On reflection, that commit probably should not have been merged in the first place. On top of not working that well and causing a severe performance degradation on Windows for image generation, there is a much simpler alternative:

If we drop the `--export-all-symbols` flag in PackageCompiler, Julia already labels any `@ccallable` and required functions in the sysimage as `__declspec(dllexport)` automatically, so the only additional annotation requirements are on any `.c` files provided by the user. Disabling auto-export of all symbols means that the sysimage ends up with ~15 symbols exported, instead of ~45k+

Removing this flag allows us to backport https://github.com/JuliaLang/julia/pull/59736 to Julia 1.10 (fixing the performance regression for package compiler) and avoid the "ordinal too large" error above, at the ~minor cost of the user needing to annotate their code with `dllexport` on Windows. Since explicit exports are the standard platform behavior on Windows, this seems like a reasonable compromise.


**master** (Julia 1.10):
```
C:\Program Files\Microsoft Visual Studio\2022\Community>dumpbin /EXPORTS mylib.dll # before
...
       46195 number of functions
       46195 number of names
```
**PR** (Julia 1.10):
```
C:\Program Files\Microsoft Visual Studio\2022\Community>dumpbin /EXPORTS mylib.dll
...
           6 number of functions
           6 number of names
```
