### PR TITLE
Locate the private libraries with julia_private_libdir()

### DIFF
--- a/src/PackageCompiler.jl
+++ b/src/PackageCompiler.jl
@@ -1399,17 +1399,12 @@ end
 
 function bundle_julia_libraries(dest_dir, stdlibs; quiet::Bool=false)
     app_lib_dir = joinpath(dest_dir, Sys.isunix() ? "lib" : "bin")
-    app_libjulia_dir = Sys.isunix() ? joinpath(app_lib_dir, "julia") : app_lib_dir
     lib_dir = julia_libdir()
-    libjulia_dir = Sys.isunix() ? joinpath(lib_dir, "julia") : lib_dir
-    # File structure is different on locally built julias:
-    # libraries are in lib/ directly instead of lib/julia/, and the DEP_LIBS
-    # embedded in libjulia.so reflect this. We must copy libraries to the same
-    # relative location to match the binary's expectations.
-    if is_local_julia_build()
-        libjulia_dir = lib_dir
-        app_libjulia_dir = app_lib_dir
-    end
+    libjulia_dir = julia_private_libdir()
+    # The file structure is different on locally built julias: private libraries are in lib/
+    # directly instead of lib/julia/, and the DEP_LIBS embedded in libjulia.so reflect this.
+    # We must copy libraries to the same relative location to match the binary's expectations.
+    app_libjulia_dir = libjulia_dir == lib_dir ? app_lib_dir : joinpath(app_lib_dir, "julia")
 
     mkpath(app_lib_dir)
     # Always create lib/julia/ for the sysimage (even for local builds where libraries go to lib/)

--- a/src/juliaconfig.jl
+++ b/src/juliaconfig.jl
@@ -13,13 +13,6 @@ function julia_libdir()
     return dirname(abspath(Libdl.dlpath(libname)))
 end
 
-# Detect if Julia is a local build (libraries in lib/ directly instead of lib/julia/)
-function is_local_julia_build()
-    lib_dir = julia_libdir()
-    # In local builds, libLLVM is directly in lib/, not in lib/julia/
-    return any(startswith(f, "libLLVM") for f in readdir(lib_dir))
-end
-
 function julia_private_libdir()
     if Base.DARWIN_FRAMEWORK # taken from Libdl tests
         if isdebugbuild() != 0

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -55,6 +55,21 @@ function rm_with_retry(path; recursive::Bool=false, force::Bool=false,
 end
 
 @testset "PackageCompiler.jl" begin
+    @testset "julia_libdir / julia_private_libdir" begin
+        lib_dir = PackageCompiler.julia_libdir()
+        private_libdir = PackageCompiler.julia_private_libdir()
+        @test isdir(lib_dir)
+        @test isdir(private_libdir)
+        for lib in ("libjulia-codegen", "libjulia-internal")
+            @test !isempty(PackageCompiler.glob(PackageCompiler.glob_pattern_lib(lib), private_libdir))
+        end
+        # `bundle_julia_libraries` reproduces this layout inside the bundle. Framework
+        # builds are the exception: they keep the private libraries in `Frameworks/`.
+        if !Base.DARWIN_FRAMEWORK
+            @test private_libdir in (lib_dir, joinpath(lib_dir, "julia"))
+        end
+    end
+
     @testset "create_sysimage" begin
     new_project = mktempdir()
     old_project = Base.ACTIVE_PROJECT[]


### PR DESCRIPTION
I ran into build issues after starting to use Julia in a Pixi environment as described in https://discourse.julialang.org/t/julia-forge-a-conda-channel-for-official-julia/138511. The cause was a heuristic that detects local Julia builds by finding libraries starting with libLLVM, which is wrong in my case. I used Claude Opus 5 to find and fix the issue, and write the text below. I did review, and can confirm this fixes our issue, we are already usign this fork in https://github.com/Deltares/Ribasim/pull/3182.

---

`bundle_julia_libraries` has to copy two sets of libraries to two places: `libjulia*` from `julia_libdir()` into `<bundle>/lib`, and the private libraries (`libjulia-internal`, `libuv`, `libunwind`, `libgmp`, the stdlib JLLs, …) into either `<bundle>/lib/julia` or `<bundle>/lib`, depending on how this Julia is laid out. The destination has to mirror the source, because `libjulia`'s `DEP_LIBS` and the `RUNPATH` written by `create_app`/`create_library` encode the relative path.

Until now the source was assumed to be `julia_libdir()/julia`, with an escape hatch for local builds detected like this:

```julia
function is_local_julia_build()
    lib_dir = julia_libdir()
    # In local builds, libLLVM is directly in lib/, not in lib/julia/
    return any(startswith(f, "libLLVM") for f in readdir(lib_dir))
end
```

This infers a *layout* from an *unrelated file*, and only holds if nothing else can put `libLLVM*` next to `libjulia`. That assumption breaks as soon as Julia is installed into a shared prefix. In a conda/pixi environment, `rust`, `llvmlite`, `libclang-cpp`, `numba` and `libllvm*` all install `libLLVM*.so` into `$PREFIX/lib`, which is also `julia_libdir()`.

### Symptoms

`is_local_julia_build()` returns `true`, so the private libraries are looked for in `$PREFIX/lib` instead of `$PREFIX/lib/julia`. The `required_libraries` globs match nothing useful, and the resulting bundle:

* has an **empty** `lib/julia` (it is still `mkpath`'d for the sysimage, so the directory exists);
* is missing `libjulia-internal`, `libuv`, `libunwind`, `libdSFMT`, `libopenlibm`, `libpcre2`, `libgmp`, `libmpfr`;
* still contains `libjulia.so*`, which is copied separately by an exact regex over `lib_dir`, so it looks plausible;
* instead contains the *environment's* `libLLVM.so.22.1` (195 MB), `libstdc++`, `libz`, `libzstd`, `libgomp`, `libquadmath`, `libatomic`, `libgcc_s`.

Nothing errors — `create_library` exits 0 — and the failure only appears at load time:

```
$ ldd libmini.so
        libjulia.so.1.12 => .../lib/../lib/libjulia.so.1.12
        libjulia-internal.so.1.12 => not found
```

Reproducer:

```bash
pixi init repro && cd repro
pixi workspace channel add https://prefix.dev/julia-forge
pixi add https://prefix.dev/julia-forge::julia
pixi add libllvm22     # or rust, numba, gdal, ...
pixi run julia -e 'using PackageCompiler; @show PackageCompiler.is_local_julia_build()'  # true
```

Note the Julia install itself is fine here — julia-forge uses the standard `lib/` + `lib/julia/` layout. It is the shared prefix that defeats the heuristic.

### The change

Stop guessing and ask Julia where its private libraries are. `julia_private_libdir()` is `dirname(dlpath("libjulia-internal"))`, so it is correct by construction; comparing it with `julia_libdir()` then yields the bundle layout:

```julia
lib_dir = julia_libdir()
libjulia_dir = julia_private_libdir()
app_libjulia_dir = libjulia_dir == lib_dir ? app_lib_dir : joinpath(app_lib_dir, "julia")
```

| Julia install | `julia_libdir()` | `julia_private_libdir()` | `app_libjulia_dir` |
|---|---|---|---|
| official release | `lib` | `lib/julia` | `<bundle>/lib/julia` |
| conda / pixi | `$PREFIX/lib` | `$PREFIX/lib/julia` | `<bundle>/lib/julia` |
| local build | `usr/lib` | `usr/lib` | `<bundle>/lib` |
| Windows | bin | bin | `<bundle>/bin` |

The last two rows are why both `is_local_julia_build()` and the `Sys.isunix()` branch could go: a local build has `Base.PRIVATE_LIBDIR == Base.LIBDIR`, and on Windows everything is in bin, so plain equality already covers both cases. `is_local_julia_build()` had no other callers and is removed. The unconditional `mkpath(joinpath(app_lib_dir, "julia"))` is unchanged, since the sysimage goes there regardless.

### Verification

Against the pixi reproducer above, before and after:

```
before: lib/julia = 0 entries;  libjulia-internal.so.1.12 => not found
after:  lib/julia = 59 entries; libjulia-internal.so.1.12 => .../lib/julia/libjulia-internal.so.1.12
```

Every `lib/julia` entry in the fixed bundle is byte-identical to `$PREFIX/lib/julia`, and `lib/` contains only `libjulia.so*` plus the product — the conda `libLLVM` is gone. The one intentional exception is `libstdc++`, which `_copy_julia_libraries` deliberately takes from `Libdl.dllist()` rather than globbing.

Also verified unchanged on an official 1.12.6 tarball install.

### Tests

Adds a unit test for the two accessors, which had none. It pins the invariant the bundling code depends on:

```julia
@testset "julia_libdir / julia_private_libdir" begin
    lib_dir = PackageCompiler.julia_libdir()
    private_libdir = PackageCompiler.julia_private_libdir()
    @test isdir(lib_dir)
    @test isdir(private_libdir)
    for lib in ("libjulia-codegen", "libjulia-internal")
        @test !isempty(PackageCompiler.glob(PackageCompiler.glob_pattern_lib(lib), private_libdir))
    end
    # `bundle_julia_libraries` reproduces this layout inside the bundle. Framework
    # builds are the exception: they keep the private libraries in `Frameworks/`.
    if !Base.DARWIN_FRAMEWORK
        @test private_libdir in (lib_dir, joinpath(lib_dir, "julia"))
    end
end
```

Passes on both an official tarball Julia and the conda/pixi Julia that triggered the bug.
