### PR TITLE
Remove obsolete sysimage creation workaround

### DIFF
--- a/.github/workflows/ci.nightly.yml
+++ b/.github/workflows/ci.nightly.yml
@@ -52,7 +52,7 @@ jobs:
           # If `julia-wordsize` is 64, then we set `arch` to `${{ runner.arch }}`, which
           # GitHub will automatically expand to the correct value (`x86_64` or `aarch64`)
           # based on the architecture of the underlying GitHub Runner (virtual machine).
-          arch: ${{ github.ref == '32' && 'x86' || runner.arch }}
+          arch: ${{ matrix.julia-wordsize == '32' && 'x86' || runner.arch }}
       - uses: julia-actions/cache@d10a6fd8f31b12404a54613ebad242900567f2b9 # v2.1.0
       - uses: julia-actions/julia-runtest@678da69444cd5f13d7e674a90cb4f534639a14f9 # v1.11.2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,7 @@ jobs:
           # If `julia-wordsize` is 64, then we set `arch` to `${{ runner.arch }}`, which
           # GitHub will automatically expand to the correct value (`x86_64` or `aarch64`)
           # based on the architecture of the underlying GitHub Runner (virtual machine).
-          arch: ${{ github.ref == '32' && 'x86' || runner.arch }}
+          arch: ${{ matrix.julia-wordsize == '32' && 'x86' || runner.arch }}
       - uses: julia-actions/cache@d10a6fd8f31b12404a54613ebad242900567f2b9 # v2.1.0
       - uses: julia-actions/julia-runtest@678da69444cd5f13d7e674a90cb4f534639a14f9 # v1.11.2
         with:

--- a/src/PackageCompiler.jl
+++ b/src/PackageCompiler.jl
@@ -1238,10 +1238,31 @@ function create_library(package_or_project::String,
     compat_file = get_library_filename(lib_name; version, compat_level)
     soname = (Sys.isunix() && !Sys.isapple()) ? compat_file : nothing
 
-    create_sysimage_workaround(ctx, sysimg_path, precompile_execution_file,
-        precompile_statements_file, incremental, filter_stdlibs, cpu_target;
-        sysimage_build_args, compress_sysimage, include_transitive_dependencies,
-        julia_init_c_file, julia_init_h_file, version, soname, script, base_sysimage)
+    if ctx.env.pkg === nothing
+        # If environment is not a package, create sysimage with all packages in project
+        packages = nothing
+    else
+        # Otherwise, only include package in sysimage
+        packages = [ctx.env.pkg.name]
+    end
+
+    create_sysimage(packages;
+                    sysimage_path=sysimg_path,
+                    project=dirname(ctx.env.project_file),
+                    precompile_execution_file,
+                    precompile_statements_file,
+                    incremental,
+                    filter_stdlibs,
+                    cpu_target,
+                    script,
+                    sysimage_build_args,
+                    compress_sysimage,
+                    include_transitive_dependencies,
+                    base_sysimage,
+                    julia_init_c_file,
+                    julia_init_h_file,
+                    version,
+                    soname)
 
     if version !== nothing && Sys.isunix()
         cd(dirname(sysimg_path)) do
@@ -1287,62 +1308,6 @@ function get_library_filename(name::String;
     return sysimg_file
 end
 
-# Use workaround at https://github.com/JuliaLang/julia/issues/34064#issuecomment-563950633
-# by first creating a normal "empty" sysimage and then use that to finally create the one
-# with the @ccallable function.
-# This function can be removed when https://github.com/JuliaLang/julia/pull/37530 is merged
-function create_sysimage_workaround(
-                    ctx,
-                    sysimage_path::String,
-                    precompile_execution_file::Union{String, Vector{String}},
-                    precompile_statements_file::Union{String, Vector{String}},
-                    incremental::Bool,
-                    filter_stdlibs::Bool,
-                    cpu_target::String;
-                    sysimage_build_args::Cmd,
-                    compress_sysimage::Bool=false,
-                    include_transitive_dependencies::Bool,
-                    julia_init_c_file::Union{Nothing,String,Vector{String}},
-                    julia_init_h_file::Union{Nothing,String,Vector{String}},
-                    version::Union{Nothing,VersionNumber},
-                    soname::Union{Nothing,String},
-                    script::Union{Nothing,String},
-                    base_sysimage::Union{Nothing, String} = nothing
-                    )
-    project = dirname(ctx.env.project_file)
-
-    if !incremental
-        tmp = mktempdir()
-        base_sysimage = joinpath(tmp, "tmp_sys." * Libdl.dlext)
-        create_sysimage(String[]; sysimage_path=base_sysimage, project,
-                        incremental=false, filter_stdlibs, cpu_target)
-    end
-
-    if ctx.env.pkg === nothing
-        # If environment is not a package, create sysimage with all packages in project
-        packages = nothing
-    else
-        # Otherwise, only include package in sysimage
-        packages = [ctx.env.pkg.name]
-    end
-
-    create_sysimage(packages; sysimage_path, project,
-                    incremental=true,
-                    script=script,
-                    precompile_execution_file,
-                    precompile_statements_file,
-                    cpu_target,
-                    base_sysimage,
-                    julia_init_c_file,
-                    julia_init_h_file,
-                    version,
-                    soname,
-                    sysimage_build_args,
-                    compress_sysimage,
-                    include_transitive_dependencies)
-
-    return
-end
 ############
 # Bundling #
 ############

--- a/src/PackageCompiler.jl
+++ b/src/PackageCompiler.jl
@@ -277,6 +277,23 @@ function get_julia_cmd()
     end
 end
 
+supports_sysimage_compression() = hasfield(typeof(Base.JLOptions()), :compress_sysimage)
+
+# Windows fails to load DLLs of 2 GiB or more with the cryptic error
+# "%1 is not a valid Win32 application".
+const WINDOWS_DLL_SIZE_LIMIT = 2^31
+function warn_if_sysimage_too_big(sysimage_path::String)
+    Sys.iswindows() || return
+    sysimage_size = filesize(sysimage_path)
+    sysimage_size < WINDOWS_DLL_SIZE_LIMIT && return
+    size_gib = round(sysimage_size / 2^30; digits=2)
+    compress_hint = supports_sysimage_compression() ? " passing `compress_sysimage=true`," : ""
+    @warn "The generated sysimage is $size_gib GiB, which is over the 2 GiB limit for " *
+          "loading DLLs on Windows, so it will likely fail to load. Consider$compress_hint " *
+          "including fewer packages in the sysimage, or using `filter_stdlibs=true`."
+    return
+end
+
 
 function rewrite_sysimg_jl_only_needed_stdlibs()
     sysimg_source_path = Base.find_source_file("sysimg.jl")
@@ -607,6 +624,10 @@ compiler (can also include extra arguments to the compiler, like `-g`).
 
 - `sysimage_build_args::Cmd`: A set of command line options that is used in the Julia process building the sysimage,
   for example `-O1 --check-bounds=yes`.
+
+- `compress_sysimage::Bool`: If `true`, compress the sysimage data at the expense
+  of slightly increased load time. This is particularly useful on Windows where sysimages of
+  2 GiB or more fail to load. Requires Julia v1.13 or later. Defaults to `false`.
 """
 function create_sysimage(packages::Union{Nothing, Symbol, Vector{String}, Vector{Symbol}}=nothing;
                          sysimage_path::String,
@@ -618,6 +639,7 @@ function create_sysimage(packages::Union{Nothing, Symbol, Vector{String}, Vector
                          cpu_target::String=NATIVE_CPU_TARGET,
                          script::Union{Nothing, String}=nothing,
                          sysimage_build_args::Cmd=``,
+                         compress_sysimage::Bool=false,
                          include_transitive_dependencies::Bool=true,
                          # Internal args
                          base_sysimage::Union{Nothing, String}=nothing,
@@ -639,6 +661,13 @@ function create_sysimage(packages::Union{Nothing, Symbol, Vector{String}, Vector
 
     if filter_stdlibs && incremental
         error("must use `incremental=false` to use `filter_stdlibs=true`")
+    end
+
+    if compress_sysimage
+        if !supports_sysimage_compression()
+            error("`compress_sysimage=true` requires Julia v1.13 or later")
+        end
+        sysimage_build_args = `$sysimage_build_args --compress-sysimage=yes`
     end
 
     ctx = create_pkg_context(project)
@@ -771,6 +800,8 @@ function create_sysimage(packages::Union{Nothing, Symbol, Vector{String}, Vector
             run(cmd)
         end
     end
+
+    warn_if_sysimage_too_big(sysimage_path)
 
     return nothing
 end
@@ -912,6 +943,10 @@ compiler (can also include extra arguments to the compiler, like `-g`).
 - `sysimage_build_args::Cmd`: A set of command line options that is used in the Julia process building the sysimage,
   for example `-O1 --check-bounds=yes`.
 
+- `compress_sysimage::Bool`: If `true`, compress the sysimage data at the expense
+  of slightly increased load time. This is particularly useful on Windows where sysimages of
+  2 GiB or more fail to load. Requires Julia v1.13 or later. Defaults to `false`.
+
 - `script::String`: Path to a file that gets executed in the `--output-o` process.
 """
 function create_app(package_dir::String,
@@ -926,6 +961,7 @@ function create_app(package_dir::String,
                     cpu_target::String=default_app_cpu_target(),
                     include_lazy_artifacts::Bool=false,
                     sysimage_build_args::Cmd=``,
+                    compress_sysimage::Bool=false,
                     include_transitive_dependencies::Bool=true,
                     include_preferences::Bool=true,
                     script::Union{Nothing, String}=nothing,
@@ -981,6 +1017,7 @@ function create_app(package_dir::String,
                     precompile_statements_file,
                     cpu_target,
                     sysimage_build_args,
+                    compress_sysimage,
                     include_transitive_dependencies,
                     extra_precompiles = join(precompiles, "\n"),
                     script)
@@ -1116,6 +1153,10 @@ compiler (can also include extra arguments to the compiler, like `-g`).
 
 - `sysimage_build_args::Cmd`: A set of command line options that is used in the Julia process building the sysimage,
   for example `-O1 --check-bounds=yes`.
+
+- `compress_sysimage::Bool`: If `true`, compress the sysimage data at the expense
+  of slightly increased load time. This is particularly useful on Windows where sysimages of
+  2 GiB or more fail to load. Requires Julia v1.13 or later. Defaults to `false`.
 """
 function create_library(package_or_project::String,
                         dest_dir::String;
@@ -1133,6 +1174,7 @@ function create_library(package_or_project::String,
                         cpu_target::String=default_app_cpu_target(),
                         include_lazy_artifacts::Bool=false,
                         sysimage_build_args::Cmd=``,
+                        compress_sysimage::Bool=false,
                         include_transitive_dependencies::Bool=true,
                         include_preferences::Bool=true,
                         script::Union{Nothing,String}=nothing,
@@ -1187,8 +1229,8 @@ function create_library(package_or_project::String,
 
     create_sysimage_workaround(ctx, sysimg_path, precompile_execution_file,
         precompile_statements_file, incremental, filter_stdlibs, cpu_target;
-        sysimage_build_args, include_transitive_dependencies, julia_init_c_file,
-        julia_init_h_file, version, soname, script, base_sysimage)
+        sysimage_build_args, compress_sysimage, include_transitive_dependencies,
+        julia_init_c_file, julia_init_h_file, version, soname, script, base_sysimage)
 
     if version !== nothing && Sys.isunix()
         cd(dirname(sysimg_path)) do
@@ -1247,6 +1289,7 @@ function create_sysimage_workaround(
                     filter_stdlibs::Bool,
                     cpu_target::String;
                     sysimage_build_args::Cmd,
+                    compress_sysimage::Bool=false,
                     include_transitive_dependencies::Bool,
                     julia_init_c_file::Union{Nothing,String,Vector{String}},
                     julia_init_h_file::Union{Nothing,String,Vector{String}},
@@ -1284,6 +1327,7 @@ function create_sysimage_workaround(
                     version,
                     soname,
                     sysimage_build_args,
+                    compress_sysimage,
                     include_transitive_dependencies)
 
     return

--- a/src/PackageCompiler.jl
+++ b/src/PackageCompiler.jl
@@ -752,45 +752,48 @@ function create_sysimage(packages::Union{Nothing, String, Symbol, Vector{String}
     # work on macOS.
     # Bug report: https://github.com/JuliaLang/PackageCompiler.jl/issues/738
     # PR: https://github.com/JuliaLang/PackageCompiler.jl/pull/930
-
-    create_sysimg_object_file(object_file, packages, packages_sysimg;
-                            project,
-                            base_sysimage,
-                            precompile_execution_file,
-                            precompile_statements_file,
-                            cpu_target,
-                            script,
-                            sysimage_build_args,
-                            extra_precompiles,
-                            incremental,
-                            import_into_main)
     object_files = [object_file]
-    if julia_init_c_file !== nothing
-        if julia_init_c_file isa String
-            julia_init_c_file = [julia_init_c_file]
+    try
+        create_sysimg_object_file(object_file, packages, packages_sysimg;
+                                project,
+                                base_sysimage,
+                                precompile_execution_file,
+                                precompile_statements_file,
+                                cpu_target,
+                                script,
+                                sysimage_build_args,
+                                extra_precompiles,
+                                incremental,
+                                import_into_main)
+        if julia_init_c_file !== nothing
+            if julia_init_c_file isa String
+                julia_init_c_file = [julia_init_c_file]
+            end
+            mktempdir() do include_dir
+                if julia_init_h_file !== nothing
+                    if julia_init_h_file isa String
+                        julia_init_h_file = [julia_init_h_file]
+                    end
+                    for f in julia_init_h_file
+                        cp(f, joinpath(include_dir, basename(f)))
+                    end
+                end
+                for f in julia_init_c_file
+                    filename = compile_c_init_julia(f, basename(sysimage_path), include_dir)
+                    push!(object_files, filename)
+                end
+            end
         end
-        mktempdir() do include_dir
-            if julia_init_h_file !== nothing
-                if julia_init_h_file isa String
-                    julia_init_h_file = [julia_init_h_file]
-                end
-                for f in julia_init_h_file
-                    cp(f, joinpath(include_dir, basename(f)))
-                end
-            end
-            for f in julia_init_c_file
-                filename = compile_c_init_julia(f, basename(sysimage_path), include_dir)
-                push!(object_files, filename)
-            end
+        create_sysimg_from_object_file(object_files,
+                                    sysimage_path;
+                                    compat_level,
+                                    version,
+                                    soname)
+    finally
+        foreach(object_files) do file
+            rm(file; force=true)
         end
     end
-    create_sysimg_from_object_file(object_files,
-                                sysimage_path;
-                                compat_level,
-                                version,
-                                soname)
-
-    rm(object_file; force=true)
 
     if Sys.isapple()
         cd(dirname(abspath(sysimage_path))) do
@@ -849,9 +852,14 @@ function compile_c_init_julia(julia_init_c_file::String, sysimage_name::String, 
     @debug "Compiling $julia_init_c_file"
     flags = Base.shell_split(cflags())
 
-    o_init_file = splitext(julia_init_c_file)[1] * ".o"
+    o_init_file = tempname() * ".o"
     cmd = `-c -I$include_dir -DJULIAC_PROGRAM_LIBNAME=$(repr(sysimage_name)) $TLS_SYNTAX $(bitflag()) $flags $(march()) -o $o_init_file $julia_init_c_file`
-    run_compiler(cmd)
+    try
+        run_compiler(cmd)
+    catch
+        rm(o_init_file; force=true)
+        rethrow()
+    end
     return o_init_file
 end
 
@@ -1182,6 +1190,9 @@ function create_library(package_or_project::String,
                         quiet::Bool=false
                         )
 
+    # Avoid adding the default init header to a vector owned by the caller.
+    header_files = copy(header_files)
+
     # Add init header files to list of bundled header files if not already present
     if julia_init_h_file isa String
         julia_init_h_file = [julia_init_h_file]
@@ -1236,8 +1247,8 @@ function create_library(package_or_project::String,
         cd(dirname(sysimg_path)) do
             base_file = get_library_filename(lib_name)
             @debug "creating symlinks for $compat_file and $base_file"
-            symlink(sysimg_file, compat_file)
-            symlink(sysimg_file, base_file)
+            compat_file == sysimg_file || symlink(sysimg_file, compat_file)
+            base_file == sysimg_file || symlink(sysimg_file, base_file)
         end
     end
 end

--- a/src/PackageCompiler.jl
+++ b/src/PackageCompiler.jl
@@ -186,6 +186,42 @@ function check_packages_in_project(ctx, packages)
     end
 end
 
+function package_ids_for_sysimage(ctx, packages; include_transitive_dependencies::Bool)
+    frontier = Set{Base.PkgId}()
+    for pkg in packages
+        pkgid = if ctx.env.pkg !== nothing && pkg == ctx.env.pkg.name
+            Base.PkgId(ctx.env.pkg.uuid, pkg)
+        else
+            Base.PkgId(ctx.env.project.deps[pkg], pkg)
+        end
+        push!(frontier, pkgid)
+    end
+
+    packages_sysimg = copy(frontier)
+    include_transitive_dependencies || return packages_sysimg
+
+    new_frontier = Set{Base.PkgId}()
+    while !isempty(frontier)
+        for pkgid in frontier
+            deps = if ctx.env.pkg !== nothing && pkgid.uuid == ctx.env.pkg.uuid
+                ctx.env.project.deps
+            else
+                ctx.env.manifest[pkgid.uuid].deps
+            end
+            for (name, uuid) in deps
+                pkgid_dep = Base.PkgId(uuid, name)
+                if !(pkgid_dep in packages_sysimg)
+                    push!(packages_sysimg, pkgid_dep)
+                    push!(new_frontier, pkgid_dep)
+                end
+            end
+        end
+        copy!(frontier, new_frontier)
+        empty!(new_frontier)
+    end
+    return packages_sysimg
+end
+
 
 ##############
 # Misc utils #
@@ -629,7 +665,7 @@ compiler (can also include extra arguments to the compiler, like `-g`).
   of slightly increased load time. This is particularly useful on Windows where sysimages of
   2 GiB or more fail to load. Requires Julia v1.13 or later. Defaults to `false`.
 """
-function create_sysimage(packages::Union{Nothing, Symbol, Vector{String}, Vector{Symbol}}=nothing;
+function create_sysimage(packages::Union{Nothing, String, Symbol, Vector{String}, Vector{Symbol}}=nothing;
                          sysimage_path::String,
                          project::String=dirname(active_project()),
                          precompile_execution_file::Union{String, Vector{String}}=String[],
@@ -701,45 +737,9 @@ function create_sysimage(packages::Union{Nothing, Symbol, Vector{String}, Vector
 
     ensurecompiled(project, packages, base_sysimage)
 
-    packages_sysimg = Set{Base.PkgId}()
-
-    if include_transitive_dependencies
-        # We are not sure that packages actually load their dependencies on `using`
-        # but we still want them to end up in the sysimage. Therefore, explicitly
-        # collect their dependencies, recursively.
-
-        frontier = Set{Base.PkgId}()
-        deps = ctx.env.project.deps
-        for pkg in packages
-            # Add all dependencies of the package
-            if ctx.env.pkg !== nothing && pkg == ctx.env.pkg.name
-                push!(frontier, Base.PkgId(ctx.env.pkg.uuid, pkg))
-            else
-                uuid = ctx.env.project.deps[pkg]
-                push!(frontier, Base.PkgId(uuid, pkg))
-            end
-        end
-        copy!(packages_sysimg, frontier)
-        new_frontier = Set{Base.PkgId}()
-        while !(isempty(frontier))
-            for pkgid in frontier
-                deps = if ctx.env.pkg !== nothing && pkgid.uuid == ctx.env.pkg.uuid
-                    ctx.env.project.deps
-                else
-                    ctx.env.manifest[pkgid.uuid].deps
-                end
-                pkgid_deps = [Base.PkgId(uuid, name) for (name, uuid) in deps]
-                for pkgid_dep in pkgid_deps
-                    if !(pkgid_dep in packages_sysimg) #
-                        push!(packages_sysimg, pkgid_dep)
-                        push!(new_frontier, pkgid_dep)
-                    end
-                end
-            end
-            copy!(frontier, new_frontier)
-            empty!(new_frontier)
-        end
-    end
+    # Requested packages must always be loaded into the sysimage. The option only
+    # controls whether their dependency graph is loaded explicitly as well.
+    packages_sysimg = package_ids_for_sysimage(ctx, packages; include_transitive_dependencies)
 
     # Add stdlibs to packages_sysimg when building from fresh base sysimage
     if !incremental && !filter_stdlibs

--- a/src/julia_init.c
+++ b/src/julia_init.c
@@ -1,6 +1,8 @@
+#include <errno.h>
 #include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 
 #ifdef _MSC_VER
 JL_DLLEXPORT char *dirname(char *);
@@ -21,26 +23,28 @@ JL_DLLEXPORT char *dirname(char *);
 #include "uv.h"
 
 static void setup_args(int argc, char **argv) {
-    uv_setup_args(argc, argv);
+    argv = uv_setup_args(argc, argv);
     jl_parse_opts(&argc, &argv);
 }
 
 static const char *get_sysimage_path(const char *libname) {
     if (libname == NULL) {
-        jl_error("julia: Specify `libname` when requesting the sysimage path");
+        fprintf(stderr,
+                "julia: Specify `libname` when requesting the sysimage path\n");
         exit(1);
     }
 
     void *handle = jl_load_dynamic_library(libname, JL_RTLD_DEFAULT, 0);
     if (handle == NULL) {
-        jl_errorf("julia: Failed to load library at %s", libname);
+        fprintf(stderr, "julia: Failed to load library at %s\n", libname);
         exit(1);
     }
 
     const char *libpath = jl_pathname_for_handle(handle);
     if (libpath == NULL) {
-        jl_errorf("julia: Failed to retrieve path name for library at %s",
-                  libname);
+        fprintf(stderr,
+                "julia: Failed to retrieve path name for library at %s\n",
+                libname);
         exit(1);
     }
 
@@ -101,7 +105,18 @@ DLLEXPORT void init_julia(int argc, char **argv) {
 #else
     char *abs_sysimage_path = realpath(sysimage_path, NULL);
 #endif
+    if (abs_sysimage_path == NULL) {
+        fprintf(stderr, "julia: Failed to resolve sysimage path at %s: %s\n",
+                sysimage_path, strerror(errno));
+        exit(1);
+    }
     char *_sysimage_path = strdup(abs_sysimage_path);
+    if (_sysimage_path == NULL) {
+        fprintf(stderr, "julia: Failed to allocate memory: %s\n",
+                strerror(errno));
+        free(abs_sysimage_path);
+        exit(1);
+    }
     char *root_dir = dirname(dirname(_sysimage_path));
     set_depot_load_path(root_dir);
 #if JULIA_VERSION_MAJOR == 1 && JULIA_VERSION_MINOR <= 11
@@ -114,6 +129,13 @@ DLLEXPORT void init_julia(int argc, char **argv) {
     // auto-constructed path would be root/lib/julia/../bin = root/lib/bin (incorrect).
     size_t bindir_len = strlen(root_dir) + 5;
     char *bindir = (char *)malloc(bindir_len);
+    if (bindir == NULL) {
+        fprintf(stderr, "julia: Failed to allocate memory: %s\n",
+                strerror(errno));
+        free(_sysimage_path);
+        free(abs_sysimage_path);
+        exit(1);
+    }
     snprintf(bindir, bindir_len, "%s/bin", root_dir);
     jl_init_with_image_file(bindir, abs_sysimage_path);
     free(bindir);

--- a/src/library_selection.jl
+++ b/src/library_selection.jl
@@ -14,9 +14,9 @@ const jll_mapping = Dict(
 
 # Manually fixup of libLLVM
 const required_libraries = Dict(
-    "windows" => ["libLLVM", "libatomic", "libdSFMT", "libgcc_s_seh", "libgfortran", "libgmp", "libgmpxx", "libgomp", "libjulia-codegen", "libjulia-internal", "libmpfr", "libopenlibm", "libpcre2", "libpcre2-16", "libpcre2-32", "libpcre2-8", "libpcre2-posix", "libquadmath", "libssp", "libstdc++", "libuv", "libwinpthread", "libz"],
-    "linux" =>   ["libLLVM", "libatomic", "libdSFMT", "libgcc_s",     "libgfortran", "libgmp", "libgmpxx", "libgomp", "libjulia-codegen", "libjulia-internal", "libmpfr", "libopenlibm", "libpcre2-8",                                                             "libquadmath", "libssp", "libstdc++", "libunwind", "libuv", "libz"],
-    "mac" =>     ["libLLVM", "libatomic", "libdSFMT", "libgcc_s",     "libgfortran", "libgmp", "libgmpxx", "libgomp", "libjulia-codegen", "libjulia-internal", "libmpfr", "libopenlibm", "libpcre2-8",                                                             "libquadmath", "libssp", "libstdc++", "libuv", "libz"]
+    "windows" => ["libLLVM", "libatomic", "libdSFMT", "libgcc_s_seh", "libgfortran", "libgmp", "libgmpxx", "libgomp", "libjulia-codegen", "libjulia-internal", "libmpfr", "libopenlibm", "libpcre2", "libpcre2-16", "libpcre2-32", "libpcre2-8", "libpcre2-posix", "libquadmath", "libssp", "libstdc++", "libuv", "libwinpthread", "libz", "libzstd"],
+    "linux" =>   ["libLLVM", "libatomic", "libdSFMT", "libgcc_s",     "libgfortran", "libgmp", "libgmpxx", "libgomp", "libjulia-codegen", "libjulia-internal", "libmpfr", "libopenlibm", "libpcre2-8",                                                             "libquadmath", "libssp", "libstdc++", "libunwind", "libuv", "libz", "libzstd"],
+    "mac" =>     ["libLLVM", "libatomic", "libdSFMT", "libgcc_s",     "libgfortran", "libgmp", "libgmpxx", "libgomp", "libjulia-codegen", "libjulia-internal", "libmpfr", "libopenlibm", "libpcre2-8",                                                             "libquadmath", "libssp", "libstdc++", "libuv", "libz", "libzstd"]
 )
 push!(required_libraries["windows"], "libgcc_s_jlj")
 push!(required_libraries["mac"], "libunwind")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -253,5 +253,12 @@ end
         # on <1.12; it doesn't know it is in a workspace
         @test length(pkgs) == 1
         @test only(pkgs).name == "Example"
+
+        # Requested packages are included even when explicit transitive loading is disabled.
+        pkgids = PackageCompiler.package_ids_for_sysimage(ctx, ["Example"];
+                                                          include_transitive_dependencies=false)
+        @test only(pkgids).name == "Example"
     end
+
+    @test applicable(create_sysimage, "Example")
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -228,7 +228,8 @@ end
         create_library(tmp_lib_src_dir, lib_target_dir; incremental=incremental, force=true, filter_stdlibs=filter,
                     precompile_execution_file=joinpath(lib_source_dir, "build", "generate_precompile.jl"),
                     precompile_statements_file=joinpath(lib_source_dir, "build", "additional_precompile.jl"),
-                    lib_name=lib_name, version=v"1.0.0")
+                    lib_name=lib_name, version=v"1.0.0", compat_level="patch")
+        @test !isfile(splitext(PackageCompiler.default_julia_init())[1] * ".o")
         rm_with_retry(tmp_lib_src_dir; recursive=true)
     end
 
@@ -261,4 +262,9 @@ end
     end
 
     @test applicable(create_sysimage, "Example")
+
+    header_files = String[]
+    missing_project = joinpath(mktempdir(), "missing")
+    @test_throws ErrorException create_library(missing_project, tempname(); header_files)
+    @test isempty(header_files)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -72,13 +72,16 @@ end
     opt_during_sysimage = Base.JLOptions().opt_level
     print_opt() = println("opt: -O\$opt_during_sysimage")
     """)
+    # Exercise sysimage compression on Julia versions that support it
+    compress_sysimage = PackageCompiler.supports_sysimage_compression()
     create_sysimage(; sysimage_path=sysimage_path,
                               project=new_project,
                               precompile_execution_file=joinpath(@__DIR__, "precompile_execution.jl"),
                               precompile_statements_file=joinpath.(@__DIR__, ["precompile_statements.jl",
                                                                               "precompile_statements2.jl"]),
                               script=script,
-                              sysimage_build_args = `-O1`
+                              sysimage_build_args = `-O1`,
+                              compress_sysimage=compress_sysimage,
                               )
 
     # Check we can load sysimage and that Example is available in Main
@@ -86,6 +89,12 @@ end
     @test occursin("Hello, foo", str)
     @test occursin("I am a script", str)
     @test occursin("opt: -O1", str)
+
+    if !PackageCompiler.supports_sysimage_compression()
+        @test_throws "requires Julia v1.13" create_sysimage(; sysimage_path=sysimage_path,
+                                                            project=new_project,
+                                                            compress_sysimage=true)
+    end
     end # testset
 
     @testset "create_app" begin


### PR DESCRIPTION
## Summary

- remove create_sysimage_workaround and build libraries directly with create_sysimage
- preserve incremental, filter_stdlibs, base_sysimage, and compress_sysimage behavior
- retire the workaround now that JuliaLang/julia#37530 is present in every supported Julia release

This PR is stacked on #1114 because it passes through the new compress_sysimage argument added there.

Closes #839.
Supersedes #1054.

## Testing

- Julia 1.12.6 on macOS arm64
- created examples/MyLib as a non-incremental library with filter_stdlibs=true
- compiled and ran the C consumer against the generated bundle; it printed Incremented value: 4

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>