### PR TITLE
docs: fix packaged app source link

### DIFF
--- a/docs/src/apps.md
+++ b/docs/src/apps.md
@@ -200,7 +200,7 @@ things so that they can be found during runtime on other machines.
 The example app uses the artifact system to depend on a very simple toy binary
 that does some simple arithmetic. It is instructive to see how the [artifact
 file](https://github.com/JuliaLang/PackageCompiler.jl/blob/master/examples/MyApp/Artifacts.toml)
-is [used in the source](https://github.com/JuliaLang/PackageCompiler.jl/blob/d722a3d91abe328ebd239e2f45660be35263ebe1/examples/MyApp/src/MyApp.jl#L7-L8).
+is [used in the source](https://github.com/JuliaLang/PackageCompiler.jl/blob/master/examples/MyApp/src/MyApp.jl#L7-L8).
 
 ### [Preferences](@id app-preferences)
 


### PR DESCRIPTION
## Summary

Replace the deleted source revision linked from the application documentation with the current example source on `master`.

Fixes #1024

## Validation

- `git diff --check`
- Verified `examples/MyApp/src/MyApp.jl` exists on upstream `master` through the GitHub Contents API
- Full Documenter build not run: Julia is not installed locally

## AI assistance

Prepared with GPT-5.6 assistance and reviewed against the current upstream example.