### PR TITLE
Fix sysimage trace examples outside the build project

### DIFF
--- a/docs/src/sysimages.md
+++ b/docs/src/sysimages.md
@@ -121,7 +121,7 @@ we can see that it needs to be compiled (it shows the function
 
 ```
 ~/NewSysImageEnv
-❯ julia -JExampleSysimage.so --trace-compile=stderr -e 'import Example; Example.hello("friend")'
+❯ julia -JExampleSysimage.so --trace-compile=stderr -e 'Example.hello("friend")'
 precompile(Tuple{typeof(Example.hello), String})
 ```
 
@@ -161,7 +161,7 @@ Using the just created system image, we can see that the `hello` function no lon
 
 ```
 ~/NewSysImageEnv
-❯ julia -JExampleSysimagePrecompile.so --trace-compile=stderr -e 'import Example; Example.hello("friend")'
+❯ julia -JExampleSysimagePrecompile.so --trace-compile=stderr -e 'Example.hello("friend")'
 
 ~/NewSysImageEnv
 ❯


### PR DESCRIPTION
Fixes #923

## Summary

- Remove the redundant Example import from both trace-compile commands in the sysimage tutorial.
- Keep the two examples consistent with the preceding explanation that Example is already loaded from the custom sysimage.

## Validation

- Reproduced the original failure with Julia 1.12.6 using both a regular Example sysimage and one built with precompile_execution_file.
- Confirmed both updated commands exit successfully without activating the build project.
- Confirmed --project=. plus the original import also succeeds as an alternative.
- Built the full documentation with julia --project=docs docs/make.jl.
- git diff --check

The documentation build completed successfully. It emitted the pre-existing $ORIGIN interpolation warning from docs/src/devdocs/binaries_part_2.md, which is unrelated to this change.

## AI assistance

AI assistance was used during investigation or implementation.