### PR TITLE
Add `--strip-metadata` to bootstrap sysimage arg filter

### DIFF
--- a/src/PackageCompiler.jl
+++ b/src/PackageCompiler.jl
@@ -371,7 +371,7 @@ function create_fresh_base_sysimage(; cpu_target::String, sysimage_build_args::C
     # we can't strip the IR from the base sysimg, so we filter out this flag
     # also presumably `--compile=all` and maybe a few others we missed here...
     sysimage_build_args_strs = map(p -> "$(p...)", values(sysimage_build_args))
-    filter!(p -> !contains(p, "--compile") && p ∉ ("--strip-ir",), sysimage_build_args_strs)
+    filter!(p -> !contains(p, "--compile") && p ∉ ("--strip-ir", "--strip-metadata"), sysimage_build_args_strs)
     sysimage_build_args = Cmd(sysimage_build_args_strs)
 
     cd(base_dir) do


### PR DESCRIPTION
Similar to `--strip-ir` this flag can impact whether a sysimage is capable of precompilation (notably it breaks `@doc` by deleting Base.Docs metadata).

Accordingly, it should only be applied during the final sysimage build of the workflow.

Folks have apparently been working around this in the wild: https://github.com/JuliaServices/StructUtils.jl/issues/45 https://github.com/JuliaServices/StructUtils.jl/issues/36