### PR TITLE
Fix libgcc_s_sjlj typo in Windows library selection

### DIFF
--- a/src/library_selection.jl
+++ b/src/library_selection.jl
@@ -18,5 +18,5 @@ const required_libraries = Dict(
     "linux" =>   ["libLLVM", "libatomic", "libdSFMT", "libgcc_s",     "libgfortran", "libgmp", "libgmpxx", "libgomp", "libjulia-codegen", "libjulia-internal", "libmpfr", "libopenlibm", "libpcre2-8",                                                             "libquadmath", "libssp", "libstdc++", "libunwind", "libuv", "libz", "libzstd"],
     "mac" =>     ["libLLVM", "libatomic", "libdSFMT", "libgcc_s",     "libgfortran", "libgmp", "libgmpxx", "libgomp", "libjulia-codegen", "libjulia-internal", "libmpfr", "libopenlibm", "libpcre2-8",                                                             "libquadmath", "libssp", "libstdc++", "libuv", "libz", "libzstd"]
 )
-push!(required_libraries["windows"], "libgcc_s_jlj")
+push!(required_libraries["windows"], "libgcc_s_sjlj")
 push!(required_libraries["mac"], "libunwind")


### PR DESCRIPTION
I found this typo; it drops libgcc_s_sjlj-1.dll from 32-bit Windows bundles. https://github.com/JuliaLang/PackageCompiler.jl/blob/1df2d202d4f599379ad6aa4ab952a72824df5aa8/src/library_selection.jl#L21

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U4vVVLAJ7cbJNr4pxynGe1